### PR TITLE
Bugfixes: getPowerState & getdValue

### DIFF
--- a/index.js
+++ b/index.js
@@ -538,11 +538,7 @@ eDomoticzAccessory.prototype = {
                 if (json.result !== undefined) {
                     var sArray = sortByKey(json.result, "Name");
                     sArray.map(function(s) {
-                        if (that.swTypeVal == 7){
-                          value = (s.LevelInt > 0) ? 1 : 0;
-                        } else {
-                          value = (s.Data == "On") ? 1 : 0;
-                        }
+                        value = (s.Status == "Off") ? 0 : 1;
                     });
                 }
                 that.log("Data Received for "+this.name+": "+value);
@@ -629,9 +625,14 @@ eDomoticzAccessory.prototype = {
                 if (json.result !== undefined) {
                     var sArray = sortByKey(json.result, "Name");
                     sArray.map(function(s) {
-                        value = s.LevelInt;
-                        that.factor = 100 / s.MaxDimLevel;
-                        value = value * that.factor;
+                        if (s.Status == "Off") {
+                            value = 0;
+                        }
+                        else {
+                            value = s.LevelInt;
+                            that.factor = 100 / s.MaxDimLevel;
+                            value = value * that.factor;
+                        }
                     });
                 }
                 this.log("Data Received for "+this.name+": "+value);


### PR DESCRIPTION
Bugfix for getPowerState because:
* On/Off switches sometimes have _"Data" : "On, Level: 93 %"_ (don't ask me why), **so checking for Data == "On" won't work.** Fixed by checking Status instead; when on: _"Status" : "On"_, when off: _"Status" : "Off"_
* **Fix will also work for Dimmers**: when off: _"Status" : "Off"_, when on _"Status" : "Set Level: 50 %"_, so there's no need for checking the swTypeVal ;)

Fix for getdValue because:
* It will only show percentage when device is actually on, when off is will show 0%