### PR TITLE
Added Hue/RGB Support for lamps with subtype 'RGBW'.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ and [Domoticz](https://github.com/domoticz/domoticz)
 
 ###Todo:
 - [ ] homebridge [plugin 2.0](https://github.com/nfarina/homebridge/pull/497) support
-- [ ] Hue/RGB
+- [x] Hue/RGB
 - [x] m3 (gas usage)
 - [x] Motion sensors
 - [x] Smoke Detectors


### PR DESCRIPTION
I have added Hue/RGB support for lamps that support RGBW in Domoticz.

The only downside is that Domoticz does not return the current colour values for the lamp.
I have worked around this issue by saving the last sent colour in the bridge.