### PR TITLE
Unsupported devices don't show as type Switch anymore

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -4,6 +4,7 @@ global.Types;
 global.UUID;
 
 module.exports = {
+    DeviceTypeSwitch: 0,
     DeviceTypeContact: 2,
     DeviceTypeBlinds: 3,
     DeviceTypeSmoke: 5,

--- a/lib/domoticz_accessory.js
+++ b/lib/domoticz_accessory.js
@@ -775,6 +775,16 @@ eDomoticzAccessory.prototype = {
       {
         switch (true)
         {
+          case this.swTypeVal == Constants.DeviceTypeSwitch: {
+            if (this.name.indexOf("Fan") > -1) {
+              var characteristic = this.getService(Service.Fan).getCharacteristic(Characteristic.On);
+              callback(characteristic, message.nvalue);
+            } else {
+              var characteristic = this.getService(Service.Switch).getCharacteristic(Characteristic.On);
+              callback(characteristic, message.nvalue);
+            }
+            break;
+          }
           case this.swTypeVal == Constants.DeviceTypeSmoke: {
               var characteristic = this.getService(Service.SmokeSensor).getCharacteristic(Characteristic.SmokeDetected);
               callback(characteristic, message.nvalue);
@@ -826,17 +836,8 @@ eDomoticzAccessory.prototype = {
             callback(targetPositionCharacteristic, position);
             break;
           }
-          default:{
-            if (this.name.indexOf("Fan") > -1) {
-              var characteristic = this.getService(Service.Fan).getCharacteristic(Characteristic.On);
-              callback(characteristic, message.nvalue);
-              break;
-            } else {
-              var characteristic = this.getService(Service.Switch).getCharacteristic(Characteristic.On);
-              callback(characteristic, message.nvalue);
-              break;
-            }
-          }
+          default:
+            break;
         }
       }
       else { // Accessory is a sensor
@@ -858,6 +859,19 @@ eDomoticzAccessory.prototype = {
         {
           switch (true)
           {
+            case this.swTypeVal == Constants.DeviceTypeSwitch: {
+                var service = false;
+                if (this.name.indexOf("Fan") > -1) {
+                    service = new Service.Fan(this.name);
+                }
+                else {
+                    service = new Service.Switch(this.name);
+                }
+
+                service.getCharacteristic(Characteristic.On).on('set', this.setPowerState.bind(this)).on('get', this.getPowerState.bind(this));
+                this.services.push(service);
+                break;
+            }
             case this.swTypeVal == Constants.DeviceTypeContact: {
               var contactService = new Service.ContactSensor(this.name);
               contactService.getCharacteristic(Characteristic.ContactSensorState).on('get', this.getStringValue.bind(this));
@@ -910,19 +924,9 @@ eDomoticzAccessory.prototype = {
               this.services.push(blindService);
               break;
             }
-            default: {
-                var service = false;
-                if (this.name.indexOf("Fan") > -1) {
-                    service = new Service.Fan(this.name);
-                }
-                else {
-                    service = new Service.Switch(this.name);
-                }
 
-                service.getCharacteristic(Characteristic.On).on('set', this.setPowerState.bind(this)).on('get', this.getPowerState.bind(this));
-                this.services.push(service);
-                break;
-            }
+            default:
+              break;
           }
         }
         else // Accessory is a sensor


### PR DESCRIPTION
Because I had changed the if clause of `getServices` in  #30 from:
[` if (typeof this.swTypeVal !=='undefined' && this.swTypeVal){ // is a switch`](https://github.com/PatchworkBoy/homebridge-eDomoticz/pull/30/files#diff-168726dbe96b3ce427e7fedce31bb0bcL1179)
to
[`if (typeof this.swTypeVal !=='undefined'){ // is a switch`](https://github.com/PatchworkBoy/homebridge-eDomoticz/pull/30/files#diff-ac6ed5cf07ff2f784ccbded0532c1862R801)
unsupported switches were also added as a "Switch".

With this pull request unsupported switches (`swTypeVal` not in our switch) are only added to HomeKit with their `AccessoryIdentifier` characteristic. This results in HomeKit showing the devices as ***Unsupported***.