### PR TITLE
MQTT Fix for invalid ssl certs at Domoticz end

### DIFF
--- a/index.js
+++ b/index.js
@@ -147,6 +147,7 @@ function eDomoticzPlatform(log, config, api) {
     this.port = config.port;
     this.room = config.roomid;
     this.api = api;
+	this.agOptions = (this.ssl==1)? {rejectUnauthorized: false}:{};
 
     if (config.mqttenable===1 && this.api)
     {
@@ -185,6 +186,7 @@ eDomoticzPlatform.prototype = {
         }
         request.get({
             url: domurl,
+            agentOptions: this.agOptions,
             headers: myopt,
             json: true
         }, function(err, response, json) {


### PR DESCRIPTION
Re: https://github.com/PatchworkBoy/homebridge-edomoticz/issues/41

Add agentOptions object with relevant rejectUnauthorized depending on state of config.ssl to avoid issues with invalid https certificates.