### PR TITLE
Update InstallGuide

### DIFF
--- a/InstallGuide
+++ b/InstallGuide
@@ -38,7 +38,7 @@ sudo chmod +x /etc/init.d/domoticz.sh
 sudo update-rc.d domoticz.sh defaults
 
 cd ~/domoticz
-sudo ./domoticz
+./domoticz
 
 [ctrl-c]
 


### PR DESCRIPTION
Not starting domoticz for the first time as 'sudo' because that will create a database that is owned by root
This could have problems when you start domoticz in a service later as a normal user