### PR TITLE
Exclude certain Domoticz devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ sudo npm update -g homebridge-edomoticz
             "port": "8080",
             "ssl": 0,
             "roomid": 0,
-            "mqtt": 1
+            "mqtt": 1,
+            "excludedDevices": []
         }
     ],
     "accessories": []
@@ -107,6 +108,13 @@ Values can be omitted from this dictionary, and the values that need overriding 
 ```
 
 to only override the port value.
+
+To prevent certain Domoticz devices from showing up in HomeBridge it is possible to exclude them by setting the "excludedDevices" parameter.
+Provide an array of Domoticz Device ID's, which can be found in the Domoticz dashboard on the "Setup > Devices" page and look for the "ID" column (not the "idx" column).
+
+```
+"excludedDevices": ["0000001","0000002"]
+```
 
 ## Tips
 

--- a/index.js
+++ b/index.js
@@ -179,6 +179,8 @@ eDomoticzPlatform.prototype = {
       return;
     }
 
+    var excludedDevices = (typeof this.config.excludedDevices !== 'undefined' ? this.config.excludedDevices : []);
+
     this.log("Fetching Domoticz lights and switches...");
 
     Domoticz.devices(this.apiBaseURL, this.room, function(devices) {
@@ -189,8 +191,11 @@ eDomoticzPlatform.prototype = {
       {
         var device = devices[i];
 
-        var accessory = new eDomoticzAccessory(this, false, device.Used, device.idx, device.Name, device.HaveDimmer, device.MaxDimLevel, device.SubType, device.Type, device.BatteryLevel, device.SwitchType, device.SwitchTypeVal, device.HardwareTypeVal, this.eve);
-        newAccessories.push(accessory);
+        // Check if we need to exclude the device
+        if (!(excludedDevices.indexOf(device.ID) > -1)) {
+            var accessory = new eDomoticzAccessory(this, false, device.Used, device.idx, device.Name, device.HaveDimmer, device.MaxDimLevel, device.SubType, device.Type, device.BatteryLevel, device.SwitchType, device.SwitchTypeVal, device.HardwareTypeVal, this.eve);
+            newAccessories.push(accessory);
+        }
       }
 
       this._cachedAccessories = newAccessories;


### PR DESCRIPTION
I've added the possibility to exclude certain Domoticz devices from being added to Homebridge since I have multiple "fake" Domoticz devices/switches, which I do not want to see in HomeKit.

I decided to do exclusion based on the Device "ID" and not the "idx" identifier since the latter is not unique (devices and scenes can have the same idx value), which might cause future issues if you ever want to include Domoticz Scenes as well.

Do you like including this feature?