### PR TITLE
Add support for doorbells

### DIFF
--- a/lib/domoticz_accessory.js
+++ b/lib/domoticz_accessory.js
@@ -328,6 +328,9 @@ eDomoticzAccessory.prototype = {
             callback(null, value);
         }.bind(this));
     },
+    getDoorbellSensorValue: function(callback) {
+        callback(null, false);
+    }, 
     getStringValue: function (callback) {
         Domoticz.deviceStatus(this, function (json) {
             var value;
@@ -914,6 +917,17 @@ eDomoticzAccessory.prototype = {
                     callback(characteristic, message.nvalue);
                     break;
                 }
+            case this.swTypeVal == Constants.DeviceTypeDoorbell:
+                {
+		    			var service = this.getService(Service.StatelessProgrammableSwitch);
+                    var characteristic = this.getCharacteristic(service, Characteristic.ProgrammableSwitchEvent);
+                    callback(characteristic, Characteristic.ProgrammableSwitchEvent.SINGLE_PRESS);
+
+                    var service = this.getService(Service.Doorbell);
+                    var characteristic = this.getCharacteristic(service, Characteristic.ProgrammableSwitchEvent);
+                    callback(characteristic, Characteristic.ProgrammableSwitchEvent.SINGLE_PRESS);
+                    break;
+                }
             case this.swTypeVal == Constants.DeviceTypeSelector:
                 {
                     var service = this.getService(Service.StatelessProgrammableSwitch);
@@ -1464,6 +1478,26 @@ eDomoticzAccessory.prototype = {
                     break;
                 }
 
+            case this.swTypeVal == Constants.DeviceTypeDoorbell:
+                {
+                    var doorbellButtonService = this.getService(Service.StatelessProgrammableSwitch);
+                    if (!doorbellButtonService) {
+                        doorbellButtonService = new Service.StatelessProgrammableSwitch(this.name);
+                    }
+                    this.getCharacteristic(doorbellButtonService, Characteristic.ProgrammableSwitchEvent).on('get', this.getSelectorValue.bind(this));
+		    			this.services.push(doorbellButtonService);
+		
+                    var doorbellSensorService = this.getService(Service.Doorbell);
+                    if (!doorbellSensorService) {
+                        doorbellSensorService = new Service.Doorbell(this.name);
+                    }
+                    this.getCharacteristic(doorbellSensorService, Characteristic.ProgrammableSwitchEvent).on('get', this.getDoorbellSensorValue.bind(this));
+                    if (this.batteryRef && this.batteryRef !== 255) { // if batteryRef == 255 we're running on mains
+                        this.gracefullyAddCharacteristic(doorbellSensorService, Characteristic.StatusLowBattery).on('get', this.getLowBatteryStatus.bind(this));
+                    }
+                    this.services.push(doorbellSensorService);
+                    break;
+                }
             case this.swTypeVal == Constants.DeviceTypeDoorLock:
                 {
                     if (this.name.indexOf("garage") > -1) {


### PR DESCRIPTION
Add the doorbell service for doorbells defined in Domoticz. 

It is not possible to use the doorbell service on it's own as you need to combine it with a different service. The most logical service I could come up with was the stateless programmable switch service as the doorbell basically also is a switch. 

When combined in this way the doorbell shows up in the Home app and allows you to turn on notifications. So whenever somebody pressed the doorbell you get a notification that says "{location} doorbell rang", where the location is name of the room where the doorbell is added.

Also, when in the same room there is also a camera present, it will basically act as a video doorbell. It shows a snapshot in the notification and allows you to look at the live video stream.

Combining it with a stateless programmable switch also offers an added bonus, but you can now configure the switch to activate a scene or turn on and off individual devices.

TLDR; doorbell with notifications, video from cam in the same room and programmable switch.