### PR TITLE
Split device of type Wind into two services

### DIFF
--- a/lib/domoticz_accessory.js
+++ b/lib/domoticz_accessory.js
@@ -1207,10 +1207,10 @@ eDomoticzAccessory.prototype = {
             case this.Type == "Wind":
                 {
                     if ('undefined' !== typeof message.svalue5) {
-                        var service = this.getService(eDomoticzServices.WindDeviceService);
-                        var windServiceCurrentCharacteristic = this.getCharacteristic(service, Characteristic.CurrentTemperature);
-                        var windCurr = Helper.cleanFloat(message.svalue5);
-                        callback(windServiceCurrentCharacteristic, windCurr);
+                        var service = this.getService(Service.TemperatureSensor);
+                        var temperatureSensorServiceCurrentCharacteristic = this.getCharacteristic(service, Characteristic.CurrentTemperature);
+                        var tempCurr = Helper.cleanFloat(message.svalue5);
+                        callback(temperatureSensorServiceCurrentCharacteristic, tempCurr);
                     }
                     if ('undefined' !== typeof message.svalue3) {
                         var service = this.getService(eDomoticzServices.WindDeviceService);
@@ -1709,11 +1709,21 @@ eDomoticzAccessory.prototype = {
                     if (!windService) {
                         windService = new eDomoticzServices.WindDeviceService(this.name);
                     }
-                    this.getCharacteristic(windService, Characteristic.CurrentTemperature).on('get', this.getTemperature.bind(this));
                     this.getCharacteristic(windService, eDomoticzServices.WindSpeed).on('get', this.getWindSpeed.bind(this));
                     this.getCharacteristic(windService, eDomoticzServices.WindChill).on('get', this.getWindChill.bind(this));
                     this.getCharacteristic(windService, eDomoticzServices.WindDirection).on('get', this.getWindDirection.bind(this));
                     this.services.push(windService);
+
+		    			var temperatureSensorService = this.getService(Service.TemperatureSensor);
+		    			if (!temperatureSensorService) {
+		    				temperatureSensorService = new Service.TemperatureSensor(this.name);
+		    			}
+
+		    			this.getCharacteristic(temperatureSensorService, Characteristic.CurrentTemperature).on('get', this.getTemperature.bind(this));
+                    this.getCharacteristic(temperatureSensorService, Characteristic.CurrentTemperature).setProps({
+                        minValue: -50
+                    });
+		    			this.services.push(temperatureSensorService);
                     break;
                 }
             case this.Type == "Rain":


### PR DESCRIPTION
A device of the type Wind exposes several characteristics, like temperature, wind speed, wind direction and wind chill. But they are all mapped to a non-standard service. While the Eve app can extract all the information, the Home app cannot. The Home app just says it is an unsupported device.

By splitting out the temperature into a separate standard service, we can make sure the Home app also works. It still does not have access to the other characteristics, but at least it does not show up as unsupported anymore and provides actual useful information.

The change does not affect the Eve app, as it will still pick up all the individual characteristics.
