### PR TITLE
Add garage door Homekit support for Inverted Door Lock

### DIFF
--- a/lib/domoticz_accessory.js
+++ b/lib/domoticz_accessory.js
@@ -988,7 +988,25 @@ eDomoticzAccessory.prototype = {
                 }
             case this.swTypeVal == Constants.DeviceTypeDoorLockInverted:
                 {
+                    if (this.name.indexOf("garage") > -1) {
+                        var command = (parseInt(message.nvalue) == 1);
 
+                        if (this.swTypeVal == Constants.DeviceTypeDoorLockInverted) {
+                            command = command;
+                        }
+
+                        var garageState = (command ? Characteristic.TargetDoorState.UNSECURED : Characteristic.TargetDoorState.SECURED);
+
+                        var service = this.getService(Service.GarageDoorOpener);
+                        var targetCharacteristic = this.getCharacteristic(service, Characteristic.TargetDoorState);
+                        callback(targetCharacteristic, garageState);
+
+                        var currentCharacteristic = this.getCharacteristic(service, Characteristic.CurrentDoorState);
+                        callback(currentCharacteristic, garageState);
+                        break;
+
+
+                    } else {
                         var command = (parseInt(message.nvalue) == 1);
 
                         if (this.swTypeVal == Constants.DeviceTypeDoorLockInverted) {
@@ -1004,6 +1022,7 @@ eDomoticzAccessory.prototype = {
                         var currentCharacteristic = this.getCharacteristic(service, Characteristic.LockCurrentState);
                         callback(currentCharacteristic, doorState);
                         break;
+                	}
                 }
             case this.swTypeVal == Constants.DeviceTypeBlinds:
             case this.swTypeVal == Constants.DeviceTypeBlindsInverted:
@@ -1534,6 +1553,18 @@ eDomoticzAccessory.prototype = {
                 }
             case this.swTypeVal == Constants.DeviceTypeDoorLockInverted:
                 {
+                    if (this.name.indexOf("garage") > -1) {
+                        var garageService = this.getService(Service.GarageDoorOpener);
+                        if (!garageService) {
+                            garageService = new Service.GarageDoorOpener(this.name);
+                        }
+                        this.getCharacteristic(garageService, Characteristic.CurrentDoorState).on('get', this.getDoorStatus.bind(this));
+                        this.getCharacteristic(garageService, Characteristic.TargetDoorState).on('get', this.getDoorStatus.bind(this)).on('set', this.setDoorStatus.bind(this));
+                        //this.getCharacteristic(garageService, Characteristic.ObstructionDetected).on('get', this.getDoorStatus.bind(this));
+
+                        this.services.push(garageService);
+                        break;
+                    } else {
 
                         var lockService = this.getService(Service.LockMechanism);
                         if (!lockService) {
@@ -1543,6 +1574,7 @@ eDomoticzAccessory.prototype = {
                         this.getCharacteristic(lockService, Characteristic.LockTargetState).on('get', this.getLockStatus.bind(this)).on('set', this.setLockInvertedStatus.bind(this));
                         this.services.push(lockService);
                         break;
+                    }
                 }
             case this.swTypeVal == Constants.DeviceTypeBlinds:
             case this.swTypeVal == Constants.DeviceTypeBlindsInverted:


### PR DESCRIPTION
I added support for garage door in Homekit based on the name "garage" for Inverted Door Lock, as requested in the following issue: https://github.com/PatchworkBoy/homebridge-edomoticz/issues/171

