### PR TITLE
Adds television support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ and [Domoticz](https://github.com/domoticz/domoticz)
 - Lock Mechanisms (inverted) - Domoticz SwitchTypeVal: 20
 - Temperature sensors (only temperature characteristic in case of T+H / T+H+B)
 - Thermostat SetPoints
+- Televisions - Domoticz SwitchTypeVal: 17
 
 ## Provides:
 ### Custom HomeKit Types (supported by 3rd Party HomeKit Apps only - eg: Elgato Eve):

--- a/index.js
+++ b/index.js
@@ -195,10 +195,6 @@ eDomoticzPlatform.prototype = {
 		this.accessories.push(accessory);	
 
 		// Register the accessories
-		if(accessory.services.length <= 1) {
-			continue; // Hide empty devices.
-		}			
-		
 		try {
 			this.api.registerPlatformAccessories("homebridge-edomoticz", "eDomoticz", [accessory.platformAccessory]);
 		} catch (e) {

--- a/index.js
+++ b/index.js
@@ -145,7 +145,7 @@ eDomoticzPlatform.prototype = {
     if (this.isSynchronizingAccessories) {
       return;
     }
-
+	
     this.isSynchronizingAccessories = true;
     var excludedDevices = (typeof this.config.excludedDevices !== 'undefined') ? this.config.excludedDevices : [];
 
@@ -175,7 +175,7 @@ eDomoticzPlatform.prototype = {
         {
           if (device.SwitchTypeVal > 0 && device.SwitchTypeVal != existingAccessory.swTypeVal)
           {
-            this.log("Device " + existingAccessory.name + " has changed it's type. Recreating...");
+            this.forceLog("Device " + existingAccessory.name + " has changed it's type. Recreating...");
             removedAccessories.push(existingAccessory);
             try {
               this.api.unregisterPlatformAccessories("homebridge-edomoticz", "eDomoticz", [existingAccessory.platformAccessory]);
@@ -229,6 +229,7 @@ eDomoticzPlatform.prototype = {
       for (var i = 0; i < removedAccessories.length; i++)
       {
         var removedAccessory = removedAccessories[i];
+		removedAccessory.removed();
         var index = this.accessories.indexOf(removedAccessory);
         this.accessories.splice(index, 1);
       }

--- a/index.js
+++ b/index.js
@@ -188,23 +188,26 @@ eDomoticzPlatform.prototype = {
           }
         }
 
+		// Generate a new accessory
+		var uuid = UUID.generate(device.idx + "_" + device.Name);
+		this.forceLog("Device: " + device.Name + " (" + device.idx + ")");
+		var accessory = new eDomoticzAccessory(this, false, false, device.Used, device.idx, device.Name, uuid, device.HaveDimmer, device.MaxDimLevel, device.SubType, device.Type, device.BatteryLevel, device.SwitchType, device.SwitchTypeVal, device.HardwareTypeVal, device.Image, this.eve);
+		this.accessories.push(accessory);	
 
-          // Generate a new accessory
-          var uuid = UUID.generate(device.idx + "_" + device.Name);
-          this.forceLog(device.Image);
-          var accessory = new eDomoticzAccessory(this, false, false, device.Used, device.idx, device.Name, uuid, device.HaveDimmer, device.MaxDimLevel, device.SubType, device.Type, device.BatteryLevel, device.SwitchType, device.SwitchTypeVal, device.HardwareTypeVal, device.Image, this.eve);
-          this.accessories.push(accessory);
-
-          try {
-            this.api.registerPlatformAccessories("homebridge-edomoticz", "eDomoticz", [accessory.platformAccessory]);
-          } catch (e) {
-            this.forceLog("Could not register platform accessory! (" + accessory.name + ")\n" + e);
-          }
-          accessory.platformAccessory.context = {device: device, uuid: uuid, eve: this.eve};
-
-
+		// Register the accessories
+		if(accessory.services.length <= 1) {
+			continue; // Hide empty devices.
+		}			
+		
+		try {
+			this.api.registerPlatformAccessories("homebridge-edomoticz", "eDomoticz", [accessory.platformAccessory]);
+		} catch (e) {
+			this.forceLog("Could not register platform accessory! (" + accessory.name + ")\n" + e);
+		}
+		accessory.platformAccessory.context = {device: device, uuid: uuid, eve: this.eve};		
       }
-
+	  	  
+	  // Remove the old accessories
       for (var i = 0; i < this.accessories.length; i++)
       {
         var removedAccessory = this.accessories[i];

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -35,5 +35,5 @@ module.exports = {
     DeviceTypeNotSupportedYet: 15, //venetianeu
     */
     DeviceTypeHoneywellHGI80: 39,
-    HardwareTypeMQTT: 43,
+    HardwareTypeMQTT: 43,	
 }

--- a/lib/domoticz.js
+++ b/lib/domoticz.js
@@ -216,7 +216,7 @@ Domoticz.updateWithURL = function(accessory, url, completion) {
 };
 
 Domoticz.isMQTTSupportedCommand = function(command, parameters) {
-  if (command == "setcolbrightnessvalue") {
+  if (command == "setcolbrightnessvalue" || command == "kodimediacommand") {
     return false;
   }
   

--- a/lib/domoticz_accessory.js
+++ b/lib/domoticz_accessory.js
@@ -5,6 +5,9 @@ var Domoticz = require('./domoticz.js').Domoticz;
 var eDomoticzServices = require('./services.js').eDomoticzServices;
 module.exports = eDomoticzAccessory;
 
+var tvAccessories = {};
+var tvInputAccessories = {};
+
 function eDomoticzAccessory(platform, platformAccessory, IsScene, status, idx, name, uuid, haveDimmer, maxDimLevel, subType, Type, batteryRef, swType, swTypeVal, hwType, image, eve) {
 
     if ((haveDimmer) || (swType == "Dimmer")) {
@@ -19,6 +22,7 @@ function eDomoticzAccessory(platform, platformAccessory, IsScene, status, idx, n
     }
 
     this.services = [];
+	this.published = false;
     this.platform = platform;
     this.IsScene = IsScene; // Domoticz Scenes ignored for now...
     this.status = status;
@@ -46,7 +50,7 @@ function eDomoticzAccessory(platform, platformAccessory, IsScene, status, idx, n
     this.offValue = "Off";
     this.cachedValues = {};
     this.hwType = hwType;
-
+	
     // Initialize default values, e.g. to get the "factor"
     var voidCallback = function () {};
     switch (true) {
@@ -82,17 +86,19 @@ eDomoticzAccessory.prototype = {
     publishServices: function () {
         var services = this.getServices();
         for (var i = 0; i < services.length; i++) {
-            var service = services[i];
-
-            var existingService = this.platformAccessory.services.find(function (eService) {
-                return eService.UUID == service.UUID && eService.subtype == service.subtype;
-            });
-
-            if (!existingService) {
-                this.platformAccessory.addService(service, this.name);
-            }
+            this.publishService(services[i]);            
         }
+		this.published = true;
     },
+	publishService: function (service) {
+		var existingService = this.platformAccessory.services.find(function (eService) {
+			return eService.UUID == service.UUID && eService.subtype == service.subtype;
+		});
+
+		if (!existingService) {
+			this.platformAccessory.addService(service, this.name);
+		}
+	},
     getService: function (name) {
         var service = false;
         try {
@@ -842,16 +848,49 @@ eDomoticzAccessory.prototype = {
 		}.bind(this));
 	},
 	setTelevisionMuteState: function (state, callback) {
-		// TODO
-		callback();
+		if (this.cachedValues[Characteristic.Mute.UUID] == state) {
+			callback();
+			return;
+		}
+		
+		this.cachedValues[Characteristic.Mute.UUID] = state;
+		Domoticz.updateDeviceStatus(this, "kodimediacommand", {
+			"action": "Mute",
+		}, function (success) {
+			callback();
+		}.bind(this));
 	},
 	getTelevisionMuteState: function (callback) {
-		// TODO
-		callback();
+		Domoticz.deviceStatus(this, function (json) {
+            var value;
+            var sArray = Helper.sortByKey(json.result, "Name");
+            sArray.map(function (s) {
+                value = (s.Data.indexOf("(muted)") > -1);
+            }.bind(this));
+            callback(null, value);
+        }.bind(this));
 	},
 	setActiveIdentifier: function (identifier, callback) {
-		this.platform.log("setActiveIdentifier: " + identifier);
-		callback(null);
+		if (identifier > 0) {
+			Domoticz.updateDeviceStatus(this, "switchlight", {
+				"switchcmd": "Set Level",
+				"level": identifier * 10
+			}, function (success) {
+				callback(null, identifier);
+			}.bind(this));
+		} else {
+			callback(null, identifier);
+		}			
+	},
+	getActiveIdentifier: function (callback) {
+		Domoticz.deviceStatus(this, function (json) {
+            var value = 0;
+            var sArray = Helper.sortByKey(json.result, "Name");
+            sArray.map(function (s) {
+				value = s.Level / 10;
+            }.bind(this));
+            callback(null, value);
+        }.bind(this));
 	},
     handleMQTTMessage: function (message, callback) {
         this.platform.log("MQTT Message received for %s.\nName:\t\t%s\nDevice:\t\t%s,%s\nIs Switch:\t%s\nSwitchTypeVal:\t%s\nMQTT Message:\n%s", this.name, this.name, this.Type, this.subType, this.isSwitch, this.swTypeVal, JSON.stringify(message, null, 4));
@@ -958,16 +997,28 @@ eDomoticzAccessory.prototype = {
                 }
 			case this.swTypeVal == Constants.DeviceTypeMedia:
 				{
+					// TV power state.
 					var tvService = this.getService(Service.Television);
-					var tvSpeakerService = this.getService(Service.TelevisionSpeaker);
 
                     var activeCharacteristic = this.getCharacteristic(tvService, Characteristic.Active);
                     var state = (message.nvalue > 0) ? Characteristic.Active.ACTIVE : Characteristic.Active.INACTIVE;
                     var oldState = this.cachedValues[Characteristic.Active.UUID];
-                    if (message.svalue1 == 0 || state != oldState) {
-                        callback(activeCharacteristic, state);
+                    if (state != oldState) {                        
                         this.cachedValues[Characteristic.Active.UUID] = state;
+						callback(activeCharacteristic, state);
                     }
+					
+					// TV mute state.					
+					var tvSpeakerService = this.getService(Service.TelevisionSpeaker);
+					
+					var mutedCharacteristic = this.getCharacteristic(tvSpeakerService, Characteristic.Mute);
+					var isMuted = value = (message.svalue1.indexOf("(muted)") > -1);
+					var oldIsMuted = this.cachedValues[Characteristic.Mute.UUID];
+                    if (isMuted != oldIsMuted) {						
+                        this.cachedValues[Characteristic.Mute.UUID] = isMuted;
+						callback(mutedCharacteristic, isMuted);
+					}
+					
 					break;
 				}
             case this.swTypeVal == Constants.DeviceTypeMotion:
@@ -979,7 +1030,7 @@ eDomoticzAccessory.prototype = {
                 }
             case this.swTypeVal == Constants.DeviceTypeDoorbell:
                 {
-		    			var service = this.getService(Service.StatelessProgrammableSwitch);
+					var service = this.getService(Service.StatelessProgrammableSwitch);
                     var characteristic = this.getCharacteristic(service, Characteristic.ProgrammableSwitchEvent);
                     callback(characteristic, Characteristic.ProgrammableSwitchEvent.SINGLE_PRESS);
 
@@ -988,7 +1039,7 @@ eDomoticzAccessory.prototype = {
                     callback(characteristic, Characteristic.ProgrammableSwitchEvent.SINGLE_PRESS);
                     break;
                 }
-            case this.swTypeVal == Constants.DeviceTypeSelector:
+            case this.swTypeVal == Constants.DeviceTypeSelector && this.image != "TV":
                 {
                     var service = this.getService(Service.StatelessProgrammableSwitch);
                     var characteristic = this.getCharacteristic(service, Characteristic.ProgrammableSwitchEvent);
@@ -1007,6 +1058,14 @@ eDomoticzAccessory.prototype = {
                     callback(characteristic, value);
                     break;
                 }
+			case this.swTypeVal == Constants.DeviceTypeSelector && this.image == "TV":
+				{
+					var tvService = tvAccessories[this.hwType.toString()].getService(Service.Television);
+                    var characteristic = this.getCharacteristic(tvService, Characteristic.ActiveIdentifier);
+					var identifier = parseInt(message.svalue1) / 10;
+					callback(characteristic, identifier);
+				}
+				break;
             case this.swTypeVal == Constants.DeviceTypeDoorLock:
                 {
                     if (this.name.indexOf("garage") > -1) {
@@ -1025,8 +1084,6 @@ eDomoticzAccessory.prototype = {
                         var currentCharacteristic = this.getCharacteristic(service, Characteristic.CurrentDoorState);
                         callback(currentCharacteristic, garageState);
                         break;
-
-
                     } else {
                         var command = (parseInt(message.nvalue) == 1);
 
@@ -1047,7 +1104,6 @@ eDomoticzAccessory.prototype = {
                 }
             case this.swTypeVal == Constants.DeviceTypeDoorLockInverted:
                 {
-
                         var command = (parseInt(message.nvalue) == 1);
 
                         if (this.swTypeVal == Constants.DeviceTypeDoorLockInverted) {
@@ -1536,7 +1592,7 @@ eDomoticzAccessory.prototype = {
 						this.mediaCommandMapping[Characteristic.RemoteKey.INFORMATION] = 'Info';
 					}					
 					
-					var tvService = this.getService(Service.Television, 'tvService');
+					var tvService = this.getService(Service.Television);
                     if (!tvService) {
                         tvService = new Service.Television(this.name);
                     }			
@@ -1549,6 +1605,7 @@ eDomoticzAccessory.prototype = {
 					this.getCharacteristic(tvService, Characteristic.RemoteKey)
 						.on('set', this.sendTelevisionRemoteKey.bind(this));					
 					this.services.push(tvService);
+					tvAccessories[this.hwType.toString()] = this;
 					
 					// TV volume.
 					var tvSpeakerService = this.getService(Service.TelevisionSpeaker);
@@ -1564,46 +1621,24 @@ eDomoticzAccessory.prototype = {
 						.on('get', this.getTelevisionMuteState.bind(this));
 					tvService.addLinkedService(tvSpeakerService);
 					this.services.push(tvSpeakerService);
-										
-					// TV input sources
-					tvService.setCharacteristic(Characteristic.ActiveIdentifier, 0);
-					tvService
-						.getCharacteristic(Characteristic.ActiveIdentifier)
-						.on('set', this.setActiveIdentifier.bind(this));
 					
-					var inputs = ["Live", "HDMI1", "HDMI2", "NPO", "Netflix"]; // TODO: retrieve from Domoticz.
+					if (this.hwType.toString() in tvInputAccessories) {
+						this.createTvInputService(tvInputAccessories[this.hwType.toString()]);
+					}
 					
-					inputs.forEach((input, index) => {						
-						var inputType;
-						switch (true) {
-							case input.match(/^TV|Live$/i):
-								inputType = Characteristic.InputSourceType.TUNER;
-								break;								 
-							case input.match(/hdmi/i):
-								inputType = Characteristic.InputSourceType.HDMI;
-								break;
-							case input.match(/ypbpr/i):
-								inputType = Characteristic.InputSourceType.COMPONENT_VIDEO;
-								break;							
-							default:
-								inputType = Characteristic.InputSourceType.APPLICATION;
-								break;
-						}
-											
-						var inputService = new Service.InputSource(input.replace(/\s/g, '').toLowerCase(), input);
-						inputService
-							.setCharacteristic(Characteristic.Identifier, index + 1)
-							.setCharacteristic(Characteristic.ConfiguredName, input)
-							.setCharacteristic(Characteristic.IsConfigured, Characteristic.IsConfigured.CONFIGURED)
-							.setCharacteristic(Characteristic.InputSourceType, inputType)
-							.setCharacteristic(Characteristic.CurrentVisibilityState, Characteristic.CurrentVisibilityState.SHOWN);
-						tvService.addLinkedService(inputService);
-						this.services.push(inputService);
-					});
-									
 					break;
 				}
-            case this.swTypeVal == Constants.DeviceTypeSelector:
+			case this.swTypeVal == Constants.DeviceTypeSelector && this.image == "TV":
+				{
+					tvInputAccessories[this.hwType.toString()] = this;
+					
+					if (this.hwType.toString() in tvAccessories) {
+						tvAccessories[this.hwType.toString()].createTvInputService(this);
+					}
+	
+					break;
+				}			
+            case this.swTypeVal == Constants.DeviceTypeSelector && this.image != "TV":
                 {
                     var selectorService = this.getService(Service.StatelessProgrammableSwitch);
                     if (!selectorService) {
@@ -1991,5 +2026,55 @@ eDomoticzAccessory.prototype = {
             }
         }
         return this.services;
-    }
+    },
+	createTvInputService: function (domoticzInputSourceAccessory) {
+		var tvService = this.services[1];
+		//tvService.setCharacteristic(Characteristic.ActiveIdentifier, 0);
+		tvService
+			.getCharacteristic(Characteristic.ActiveIdentifier)
+			.on('set', domoticzInputSourceAccessory.setActiveIdentifier.bind(domoticzInputSourceAccessory))
+			.on('get', domoticzInputSourceAccessory.getActiveIdentifier.bind(domoticzInputSourceAccessory));
+			
+		Domoticz.deviceStatus(domoticzInputSourceAccessory, function (json) {
+		var sArray = Helper.sortByKey(json.result, "Name");
+			sArray.map(function (s) {
+				var inputs = new Buffer(s.LevelNames, 'base64').toString("ascii").split("|");
+				if(inputs.length > 0 && inputs[0] == "Off") {
+					inputs.shift();
+				}
+				
+				inputs.forEach((input, index) => {
+					var inputType;
+					switch (true) {
+						case input.match(/^TV|Live$/i):
+							inputType = Characteristic.InputSourceType.TUNER;
+							break;								 
+						case input.match(/hdmi/i):
+							inputType = Characteristic.InputSourceType.HDMI;
+							break;
+						case input.match(/ypbpr/i):
+							inputType = Characteristic.InputSourceType.COMPONENT_VIDEO;
+							break;							
+						default:
+							inputType = Characteristic.InputSourceType.APPLICATION;
+							break;
+					}
+										
+					var inputService = new Service.InputSource(input.replace(/\s/g, '').toLowerCase(), input);
+					inputService
+						.setCharacteristic(Characteristic.Identifier, index + 1)
+						.setCharacteristic(Characteristic.ConfiguredName, input)
+						.setCharacteristic(Characteristic.IsConfigured, Characteristic.IsConfigured.CONFIGURED)
+						.setCharacteristic(Characteristic.InputSourceType, inputType)
+						.setCharacteristic(Characteristic.CurrentVisibilityState, Characteristic.CurrentVisibilityState.SHOWN);
+					tvService.addLinkedService(inputService);
+					this.services.push(inputService);
+					
+					if(this.published) {
+						this.publishService(inputService);
+					}
+				});						
+			}.bind(this));
+		}.bind(this));
+	}
 };

--- a/lib/domoticz_accessory.js
+++ b/lib/domoticz_accessory.js
@@ -22,7 +22,7 @@ function eDomoticzAccessory(platform, platformAccessory, IsScene, status, idx, n
     }
 
     this.services = [];
-	this.published = false;
+    this.published = false;
     this.platform = platform;
     this.IsScene = IsScene; // Domoticz Scenes ignored for now...
     this.status = status;
@@ -42,7 +42,7 @@ function eDomoticzAccessory(platform, platformAccessory, IsScene, status, idx, n
     default:
         break;
     }
-	
+    
     this.Type = Type;
     this.batteryRef = batteryRef;
     this.CounterToday = 1;
@@ -50,7 +50,7 @@ function eDomoticzAccessory(platform, platformAccessory, IsScene, status, idx, n
     this.offValue = "Off";
     this.cachedValues = {};
     this.hwType = hwType;
-	
+    
     // Initialize default values, e.g. to get the "factor"
     var voidCallback = function () {};
     switch (true) {
@@ -88,17 +88,17 @@ eDomoticzAccessory.prototype = {
         for (var i = 0; i < services.length; i++) {
             this.publishService(services[i]);            
         }
-		this.published = true;
+        this.published = true;
     },
-	publishService: function (service) {
-		var existingService = this.platformAccessory.services.find(function (eService) {
-			return eService.UUID == service.UUID && eService.subtype == service.subtype;
-		});
+    publishService: function (service) {
+        var existingService = this.platformAccessory.services.find(function (eService) {
+            return eService.UUID == service.UUID && eService.subtype == service.subtype;
+        });
 
-		if (!existingService) {
-			this.platformAccessory.addService(service, this.name);
-		}
-	},
+        if (!existingService) {
+            this.platformAccessory.addService(service, this.name);
+        }
+    },
     getService: function (name) {
         var service = false;
         try {
@@ -179,11 +179,11 @@ eDomoticzAccessory.prototype = {
             this.cachedValues[characteristic.UUID] = value;
         }.bind(this));
     },
-	setActiveState: function (state, callback, context) {
+    setActiveState: function (state, callback, context) {
         this.setPowerState(state, callback, context, Characteristic.Active);
     },
     getActiveState: function (callback) {
-		this.getPowerState(callback, Characteristic.Active);
+        this.getPowerState(callback, Characteristic.Active);
     },
     getRainfall: function (callback) {
         Domoticz.deviceStatus(this, function (json) {
@@ -819,49 +819,49 @@ eDomoticzAccessory.prototype = {
             callback(null, value);
         }.bind(this));
     },
-	sendTelevisionRemoteKey: function (key, callback) {			
-		if(this.mediaCommandMapping && key in this.mediaCommandMapping) {
-			Domoticz.updateDeviceStatus(this, "kodimediacommand", {
-				"action": this.mediaCommandMapping[key],
-			}, function (success) {
-				callback();
-			}.bind(this));
-		} else {
-			callback(new Error("Unsupported remote key!"));
-		}
-	},
-	setTelevisionVolume: function (action, callback) {
-		var domoticzAction;
-		if (action == Characteristic.VolumeSelector.INCREMENT) {
-			domoticzAction = "VolumeUp";
-		} else if (action == Characteristic.VolumeSelector.DECREMENT) {
-			domoticzAction = "VolumeDown";
-		} else {
-			callback(new Error("Unsupported volume action!"));
-			return;
-		}		
-		
-		Domoticz.updateDeviceStatus(this, "kodimediacommand", {
-			"action": domoticzAction
-		}, function (success) {
-			callback();
-		}.bind(this));
-	},
-	setTelevisionMuteState: function (state, callback) {
-		if (this.cachedValues[Characteristic.Mute.UUID] == state) {
-			callback();
-			return;
-		}
-		
-		this.cachedValues[Characteristic.Mute.UUID] = state;
-		Domoticz.updateDeviceStatus(this, "kodimediacommand", {
-			"action": "Mute",
-		}, function (success) {
-			callback();
-		}.bind(this));
-	},
-	getTelevisionMuteState: function (callback) {
-		Domoticz.deviceStatus(this, function (json) {
+    sendTelevisionRemoteKey: function (key, callback) {            
+        if(this.mediaCommandMapping && key in this.mediaCommandMapping) {
+            Domoticz.updateDeviceStatus(this, "kodimediacommand", {
+                "action": this.mediaCommandMapping[key],
+            }, function (success) {
+                callback();
+            }.bind(this));
+        } else {
+            callback(new Error("Unsupported remote key!"));
+        }
+    },
+    setTelevisionVolume: function (action, callback) {
+        var domoticzAction;
+        if (action == Characteristic.VolumeSelector.INCREMENT) {
+            domoticzAction = "VolumeUp";
+        } else if (action == Characteristic.VolumeSelector.DECREMENT) {
+            domoticzAction = "VolumeDown";
+        } else {
+            callback(new Error("Unsupported volume action!"));
+            return;
+        }        
+        
+        Domoticz.updateDeviceStatus(this, "kodimediacommand", {
+            "action": domoticzAction
+        }, function (success) {
+            callback();
+        }.bind(this));
+    },
+    setTelevisionMuteState: function (state, callback) {
+        if (this.cachedValues[Characteristic.Mute.UUID] == state) {
+            callback();
+            return;
+        }
+        
+        this.cachedValues[Characteristic.Mute.UUID] = state;
+        Domoticz.updateDeviceStatus(this, "kodimediacommand", {
+            "action": "Mute",
+        }, function (success) {
+            callback();
+        }.bind(this));
+    },
+    getTelevisionMuteState: function (callback) {
+        Domoticz.deviceStatus(this, function (json) {
             var value;
             var sArray = Helper.sortByKey(json.result, "Name");
             sArray.map(function (s) {
@@ -869,30 +869,30 @@ eDomoticzAccessory.prototype = {
             }.bind(this));
             callback(null, value);
         }.bind(this));
-	},
-	setActiveIdentifier: function (identifier, callback, context) {
-		if ((context && context == "eDomoticz-MQTT") || identifier == 0) {
+    },
+    setActiveIdentifier: function (identifier, callback, context) {
+        if ((context && context == "eDomoticz-MQTT") || identifier == 0) {
             callback();
             return;
         }
-		
-		Domoticz.updateDeviceStatus(this, "switchlight", {
-			"switchcmd": "Set Level",
-			"level": identifier * 10
-		}, function (success) {
-			callback(null, identifier);
-		}.bind(this));	
-	},
-	getActiveIdentifier: function (callback) {
-		Domoticz.deviceStatus(this, function (json) {
+        
+        Domoticz.updateDeviceStatus(this, "switchlight", {
+            "switchcmd": "Set Level",
+            "level": identifier * 10
+        }, function (success) {
+            callback(null, identifier);
+        }.bind(this));    
+    },
+    getActiveIdentifier: function (callback) {
+        Domoticz.deviceStatus(this, function (json) {
             var value = 0;
             var sArray = Helper.sortByKey(json.result, "Name");
             sArray.map(function (s) {
-				value = s.Level / 10;
+                value = s.Level / 10;
             }.bind(this));
             callback(null, value);
         }.bind(this));
-	},
+    },
     handleMQTTMessage: function (message, callback) {
         this.platform.log("MQTT Message received for %s.\nName:\t\t%s\nDevice:\t\t%s,%s\nIs Switch:\t%s\nSwitchTypeVal:\t%s\nMQTT Message:\n%s", this.name, this.name, this.Type, this.subType, this.isSwitch, this.swTypeVal, JSON.stringify(message, null, 4));
 
@@ -996,32 +996,32 @@ eDomoticzAccessory.prototype = {
                     }
                     break;
                 }
-			case this.swTypeVal == Constants.DeviceTypeMedia:
-				{
-					// TV power state.
-					var tvService = this.getService(Service.Television);
+            case this.swTypeVal == Constants.DeviceTypeMedia:
+                {
+                    // TV power state.
+                    var tvService = this.getService(Service.Television);
 
                     var activeCharacteristic = this.getCharacteristic(tvService, Characteristic.Active);
                     var state = (message.nvalue > 0) ? Characteristic.Active.ACTIVE : Characteristic.Active.INACTIVE;
                     var oldState = this.cachedValues[Characteristic.Active.UUID];
                     if (state != oldState) {                        
                         this.cachedValues[Characteristic.Active.UUID] = state;
-						callback(activeCharacteristic, state);
+                        callback(activeCharacteristic, state);
                     }
-					
-					// TV mute state.					
-					var tvSpeakerService = this.getService(Service.TelevisionSpeaker);
-					
-					var mutedCharacteristic = this.getCharacteristic(tvSpeakerService, Characteristic.Mute);
-					var isMuted = value = (message.svalue1.indexOf("(muted)") > -1);
-					var oldIsMuted = this.cachedValues[Characteristic.Mute.UUID];
-                    if (isMuted != oldIsMuted) {						
+                    
+                    // TV mute state.                    
+                    var tvSpeakerService = this.getService(Service.TelevisionSpeaker);
+                    
+                    var mutedCharacteristic = this.getCharacteristic(tvSpeakerService, Characteristic.Mute);
+                    var isMuted = value = (message.svalue1.indexOf("(muted)") > -1);
+                    var oldIsMuted = this.cachedValues[Characteristic.Mute.UUID];
+                    if (isMuted != oldIsMuted) {                        
                         this.cachedValues[Characteristic.Mute.UUID] = isMuted;
-						callback(mutedCharacteristic, isMuted);
-					}
-					
-					break;
-				}
+                        callback(mutedCharacteristic, isMuted);
+                    }
+                    
+                    break;
+                }
             case this.swTypeVal == Constants.DeviceTypeMotion:
                 {
                     var service = this.getService(Service.MotionSensor);
@@ -1031,7 +1031,7 @@ eDomoticzAccessory.prototype = {
                 }
             case this.swTypeVal == Constants.DeviceTypeDoorbell:
                 {
-					var service = this.getService(Service.StatelessProgrammableSwitch);
+                    var service = this.getService(Service.StatelessProgrammableSwitch);
                     var characteristic = this.getCharacteristic(service, Characteristic.ProgrammableSwitchEvent);
                     callback(characteristic, Characteristic.ProgrammableSwitchEvent.SINGLE_PRESS);
 
@@ -1059,14 +1059,14 @@ eDomoticzAccessory.prototype = {
                     callback(characteristic, value);
                     break;
                 }
-			case this.swTypeVal == Constants.DeviceTypeSelector && this.image == "TV":
-				{
-					var tvService = tvAccessories[this.hwType.toString()].getService(Service.Television);
+            case this.swTypeVal == Constants.DeviceTypeSelector && this.image == "TV":
+                {
+                    var tvService = tvAccessories[this.hwType.toString()].getService(Service.Television);
                     var characteristic = this.getCharacteristic(tvService, Characteristic.ActiveIdentifier);
-					var identifier = parseInt(message.svalue1) / 10;
-					callback(characteristic, identifier);
-				}
-				break;
+                    var identifier = parseInt(message.svalue1) / 10;
+                    callback(characteristic, identifier);
+                }
+                break;
             case this.swTypeVal == Constants.DeviceTypeDoorLock:
                 {
                     if (this.name.indexOf("garage") > -1) {
@@ -1573,72 +1573,72 @@ eDomoticzAccessory.prototype = {
                     this.services.push(service);
                     break;
                 }
-			case this.swTypeVal == Constants.DeviceTypeMedia:
-				{					
-					// TV control.
-					if(!this.mediaCommandMapping) {
-						this.mediaCommandMapping = {};
-						this.mediaCommandMapping[Characteristic.RemoteKey.REWIND] = 'Rewind';
-						this.mediaCommandMapping[Characteristic.RemoteKey.FAST_FORWARD] = 'FastForward';
-						this.mediaCommandMapping[Characteristic.RemoteKey.NEXT_TRACK] = 'BigStepForward';
-						this.mediaCommandMapping[Characteristic.RemoteKey.PREVIOUS_TRACK] = 'BigStepBack';
-						this.mediaCommandMapping[Characteristic.RemoteKey.ARROW_UP] = 'Up';
-						this.mediaCommandMapping[Characteristic.RemoteKey.ARROW_DOWN] = 'Down';
-						this.mediaCommandMapping[Characteristic.RemoteKey.ARROW_LEFT] = 'Left';
-						this.mediaCommandMapping[Characteristic.RemoteKey.ARROW_RIGHT] = 'Right';
-						this.mediaCommandMapping[Characteristic.RemoteKey.SELECT] = 'Select';
-						this.mediaCommandMapping[Characteristic.RemoteKey.BACK] = 'Back';
-						this.mediaCommandMapping[Characteristic.RemoteKey.EXIT] = 'Back';
-						this.mediaCommandMapping[Characteristic.RemoteKey.PLAY_PAUSE] = 'PlayPause';
-						this.mediaCommandMapping[Characteristic.RemoteKey.INFORMATION] = 'Info';
-					}					
-					
-					var tvService = this.getService(Service.Television);
+            case this.swTypeVal == Constants.DeviceTypeMedia:
+                {                    
+                    // TV control.
+                    if(!this.mediaCommandMapping) {
+                        this.mediaCommandMapping = {};
+                        this.mediaCommandMapping[Characteristic.RemoteKey.REWIND] = 'Rewind';
+                        this.mediaCommandMapping[Characteristic.RemoteKey.FAST_FORWARD] = 'FastForward';
+                        this.mediaCommandMapping[Characteristic.RemoteKey.NEXT_TRACK] = 'BigStepForward';
+                        this.mediaCommandMapping[Characteristic.RemoteKey.PREVIOUS_TRACK] = 'BigStepBack';
+                        this.mediaCommandMapping[Characteristic.RemoteKey.ARROW_UP] = 'Up';
+                        this.mediaCommandMapping[Characteristic.RemoteKey.ARROW_DOWN] = 'Down';
+                        this.mediaCommandMapping[Characteristic.RemoteKey.ARROW_LEFT] = 'Left';
+                        this.mediaCommandMapping[Characteristic.RemoteKey.ARROW_RIGHT] = 'Right';
+                        this.mediaCommandMapping[Characteristic.RemoteKey.SELECT] = 'Select';
+                        this.mediaCommandMapping[Characteristic.RemoteKey.BACK] = 'Back';
+                        this.mediaCommandMapping[Characteristic.RemoteKey.EXIT] = 'Back';
+                        this.mediaCommandMapping[Characteristic.RemoteKey.PLAY_PAUSE] = 'PlayPause';
+                        this.mediaCommandMapping[Characteristic.RemoteKey.INFORMATION] = 'Info';
+                    }                    
+                    
+                    var tvService = this.getService(Service.Television);
                     if (!tvService) {
                         tvService = new Service.Television(this.name);
-                    }			
-					tvService
-					.setCharacteristic(Characteristic.ConfiguredName, this.name)
-					.setCharacteristic(Characteristic.SleepDiscoveryMode, Characteristic.SleepDiscoveryMode.ALWAYS_DISCOVERABLE);
-					this.getCharacteristic(tvService, Characteristic.Active)
-						.on('set', this.setActiveState.bind(this))
-						.on('get', this.getActiveState.bind(this));
-					this.getCharacteristic(tvService, Characteristic.RemoteKey)
-						.on('set', this.sendTelevisionRemoteKey.bind(this));					
-					this.services.push(tvService);
-					tvAccessories[this.hwType.toString()] = this;
-					
-					// TV volume.
-					var tvSpeakerService = this.getService(Service.TelevisionSpeaker);
+                    }            
+                    tvService
+                    .setCharacteristic(Characteristic.ConfiguredName, this.name)
+                    .setCharacteristic(Characteristic.SleepDiscoveryMode, Characteristic.SleepDiscoveryMode.ALWAYS_DISCOVERABLE);
+                    this.getCharacteristic(tvService, Characteristic.Active)
+                        .on('set', this.setActiveState.bind(this))
+                        .on('get', this.getActiveState.bind(this));
+                    this.getCharacteristic(tvService, Characteristic.RemoteKey)
+                        .on('set', this.sendTelevisionRemoteKey.bind(this));                    
+                    this.services.push(tvService);
+                    tvAccessories[this.hwType.toString()] = this;
+                    
+                    // TV volume.
+                    var tvSpeakerService = this.getService(Service.TelevisionSpeaker);
                     if (!tvSpeakerService) {
                         tvSpeakerService = new Service.TelevisionSpeaker(this.name + ' volume', 'tvSpeakerService');
                     }
-					tvSpeakerService
-						.setCharacteristic(Characteristic.VolumeControlType, Characteristic.VolumeControlType.RELATIVE);
-					this.getCharacteristic(tvSpeakerService, Characteristic.VolumeSelector)
-						.on('set', this.setTelevisionVolume.bind(this));
-					this.getCharacteristic(tvSpeakerService, Characteristic.Mute)
-						.on('set', this.setTelevisionMuteState.bind(this))
-						.on('get', this.getTelevisionMuteState.bind(this));
-					tvService.addLinkedService(tvSpeakerService);
-					this.services.push(tvSpeakerService);
-					
-					if (this.hwType.toString() in tvInputAccessories) {
-						this.createTvInputService(tvInputAccessories[this.hwType.toString()]);
-					}
-					
-					break;
-				}
-			case this.swTypeVal == Constants.DeviceTypeSelector && this.image == "TV":
-				{
-					tvInputAccessories[this.hwType.toString()] = this;
-					
-					if (this.hwType.toString() in tvAccessories) {
-						tvAccessories[this.hwType.toString()].createTvInputService(this);
-					}
-	
-					break;
-				}			
+                    tvSpeakerService
+                        .setCharacteristic(Characteristic.VolumeControlType, Characteristic.VolumeControlType.RELATIVE);
+                    this.getCharacteristic(tvSpeakerService, Characteristic.VolumeSelector)
+                        .on('set', this.setTelevisionVolume.bind(this));
+                    this.getCharacteristic(tvSpeakerService, Characteristic.Mute)
+                        .on('set', this.setTelevisionMuteState.bind(this))
+                        .on('get', this.getTelevisionMuteState.bind(this));
+                    tvService.addLinkedService(tvSpeakerService);
+                    this.services.push(tvSpeakerService);
+                    
+                    if (this.hwType.toString() in tvInputAccessories) {
+                        this.createTvInputService(tvInputAccessories[this.hwType.toString()]);
+                    }
+                    
+                    break;
+                }
+            case this.swTypeVal == Constants.DeviceTypeSelector && this.image == "TV":
+                {
+                    tvInputAccessories[this.hwType.toString()] = this;
+                    
+                    if (this.hwType.toString() in tvAccessories) {
+                        tvAccessories[this.hwType.toString()].createTvInputService(this);
+                    }
+    
+                    break;
+                }            
             case this.swTypeVal == Constants.DeviceTypeSelector && this.image != "TV":
                 {
                     var selectorService = this.getService(Service.StatelessProgrammableSwitch);
@@ -1674,7 +1674,7 @@ eDomoticzAccessory.prototype = {
                         doorbellButtonService = new Service.StatelessProgrammableSwitch(this.name);
                     }
                     this.getCharacteristic(doorbellButtonService, Characteristic.ProgrammableSwitchEvent).on('get', this.getSelectorValue.bind(this));
-		    			this.services.push(doorbellButtonService);
+                        this.services.push(doorbellButtonService);
 
                     var doorbellSensorService = this.getService(Service.Doorbell);
                     if (!doorbellSensorService) {
@@ -1937,16 +1937,16 @@ eDomoticzAccessory.prototype = {
                     this.getCharacteristic(windService, eDomoticzServices.WindDirection).on('get', this.getWindDirection.bind(this));
                     this.services.push(windService);
 
-		    			var temperatureSensorService = this.getService(Service.TemperatureSensor);
-		    			if (!temperatureSensorService) {
-		    				temperatureSensorService = new Service.TemperatureSensor(this.name);
-		    			}
+                        var temperatureSensorService = this.getService(Service.TemperatureSensor);
+                        if (!temperatureSensorService) {
+                            temperatureSensorService = new Service.TemperatureSensor(this.name);
+                        }
 
-		    			this.getCharacteristic(temperatureSensorService, Characteristic.CurrentTemperature).on('get', this.getTemperature.bind(this));
+                        this.getCharacteristic(temperatureSensorService, Characteristic.CurrentTemperature).on('get', this.getTemperature.bind(this));
                     this.getCharacteristic(temperatureSensorService, Characteristic.CurrentTemperature).setProps({
                         minValue: -50
                     });
-		    			this.services.push(temperatureSensorService);
+                        this.services.push(temperatureSensorService);
                     break;
                 }
             case this.Type == "Rain":
@@ -2028,65 +2028,65 @@ eDomoticzAccessory.prototype = {
         }
         return this.services;
     },
-	createTvInputService: function (domoticzInputSourceAccessory) {
-		var tvService = this.services[1];
-		//tvService.setCharacteristic(Characteristic.ActiveIdentifier, 0);
-		tvService
-			.getCharacteristic(Characteristic.ActiveIdentifier)
-			.on('set', domoticzInputSourceAccessory.setActiveIdentifier.bind(domoticzInputSourceAccessory))
-			.on('get', domoticzInputSourceAccessory.getActiveIdentifier.bind(domoticzInputSourceAccessory));
-			
-		Domoticz.deviceStatus(domoticzInputSourceAccessory, function (json) {
-		var sArray = Helper.sortByKey(json.result, "Name");
-			sArray.map(function (s) {
-				var inputs = new Buffer(s.LevelNames, 'base64').toString("ascii").split("|");
-				if(inputs.length > 0 && inputs[0] == "Off") {
-					inputs.shift();
-				}
-				
-				inputs.forEach((input, index) => {
-					var inputType;
-					switch (true) {
-						case input.match(/^TV|Live$/i):
-							inputType = Characteristic.InputSourceType.TUNER;
-							break;								 
-						case input.match(/hdmi/i):
-							inputType = Characteristic.InputSourceType.HDMI;
-							break;
-						case input.match(/ypbpr/i):
-							inputType = Characteristic.InputSourceType.COMPONENT_VIDEO;
-							break;							
-						default:
-							inputType = Characteristic.InputSourceType.APPLICATION;
-							break;
-					}
-										
-					var inputService = new Service.InputSource(input.replace(/\s/g, '').toLowerCase(), input);
-					inputService
-						.setCharacteristic(Characteristic.Identifier, index + 1)
-						.setCharacteristic(Characteristic.ConfiguredName, input)
-						.setCharacteristic(Characteristic.IsConfigured, Characteristic.IsConfigured.CONFIGURED)
-						.setCharacteristic(Characteristic.InputSourceType, inputType)
-						.setCharacteristic(Characteristic.CurrentVisibilityState, Characteristic.CurrentVisibilityState.SHOWN);
-					tvService.addLinkedService(inputService);
-					this.services.push(inputService);
-					
-					if(this.published) {
-						this.publishService(inputService);
-					}
-				});						
-			}.bind(this));
-		}.bind(this));
-	},
-	removed: function() { // This accessory has been removed.		
-		var tvAccessoriesIndex = tvAccessories.indexOf(this);
-		if (tvAccessoriesIndex !== -1) {
-			tvAccessories.splice(tvAccessoriesIndex, 1);
-		}
-		
-		var tvInputAccessoriesIndex = tvInputAccessories.indexOf(this);
-		if (tvInputAccessoriesIndex !== -1) {
-			tvInputAccessories.splice(tvInputAccessoriesIndex, 1);
-		}
-	}
+    createTvInputService: function (domoticzInputSourceAccessory) {
+        var tvService = this.services[1];
+        //tvService.setCharacteristic(Characteristic.ActiveIdentifier, 0);
+        tvService
+            .getCharacteristic(Characteristic.ActiveIdentifier)
+            .on('set', domoticzInputSourceAccessory.setActiveIdentifier.bind(domoticzInputSourceAccessory))
+            .on('get', domoticzInputSourceAccessory.getActiveIdentifier.bind(domoticzInputSourceAccessory));
+            
+        Domoticz.deviceStatus(domoticzInputSourceAccessory, function (json) {
+        var sArray = Helper.sortByKey(json.result, "Name");
+            sArray.map(function (s) {
+                var inputs = new Buffer(s.LevelNames, 'base64').toString("ascii").split("|");
+                if(inputs.length > 0 && inputs[0] == "Off") {
+                    inputs.shift();
+                }
+                
+                inputs.forEach((input, index) => {
+                    var inputType;
+                    switch (true) {
+                        case input.match(/^TV|Live$/i):
+                            inputType = Characteristic.InputSourceType.TUNER;
+                            break;                                 
+                        case input.match(/hdmi/i):
+                            inputType = Characteristic.InputSourceType.HDMI;
+                            break;
+                        case input.match(/ypbpr/i):
+                            inputType = Characteristic.InputSourceType.COMPONENT_VIDEO;
+                            break;                            
+                        default:
+                            inputType = Characteristic.InputSourceType.APPLICATION;
+                            break;
+                    }
+                                        
+                    var inputService = new Service.InputSource(input.replace(/\s/g, '').toLowerCase(), input);
+                    inputService
+                        .setCharacteristic(Characteristic.Identifier, index + 1)
+                        .setCharacteristic(Characteristic.ConfiguredName, input)
+                        .setCharacteristic(Characteristic.IsConfigured, Characteristic.IsConfigured.CONFIGURED)
+                        .setCharacteristic(Characteristic.InputSourceType, inputType)
+                        .setCharacteristic(Characteristic.CurrentVisibilityState, Characteristic.CurrentVisibilityState.SHOWN);
+                    tvService.addLinkedService(inputService);
+                    this.services.push(inputService);
+                    
+                    if(this.published) {
+                        this.publishService(inputService);
+                    }
+                });                        
+            }.bind(this));
+        }.bind(this));
+    },
+    removed: function() { // This accessory has been removed.        
+        var tvAccessoriesIndex = tvAccessories.indexOf(this);
+        if (tvAccessoriesIndex !== -1) {
+            tvAccessories.splice(tvAccessoriesIndex, 1);
+        }
+        
+        var tvInputAccessoriesIndex = tvInputAccessories.indexOf(this);
+        if (tvInputAccessoriesIndex !== -1) {
+            tvInputAccessories.splice(tvInputAccessoriesIndex, 1);
+        }
+    }
 };

--- a/lib/domoticz_accessory.js
+++ b/lib/domoticz_accessory.js
@@ -824,9 +824,22 @@ eDomoticzAccessory.prototype = {
 			callback(new Error("Unsupported remote key!"));
 		}
 	},
-	setTelevisionVolume: function (command, callback) {
-		this.platform.log("setTelevisionVolume: " + command);
-		callback(null);
+	setTelevisionVolume: function (action, callback) {
+		var domoticzAction;
+		if (action == Characteristic.VolumeSelector.INCREMENT) {
+			domoticzAction = "VolumeUp";
+		} else if (action == Characteristic.VolumeSelector.DECREMENT) {
+			domoticzAction = "VolumeDown";
+		} else {
+			callback(new Error("Unsupported volume action!"));
+			return;
+		}		
+		
+		Domoticz.updateDeviceStatus(this, "kodimediacommand", {
+			"action": domoticzAction
+		}, function (success) {
+			callback();
+		}.bind(this));
 	},
 	setTelevisionMuteState: function (state, callback) {
 		// TODO
@@ -1405,8 +1418,6 @@ eDomoticzAccessory.prototype = {
         }
     },
     getServices: function () {
-		this.platform.log("getServices");
-
         this.services = [];
         var informationService = this.getService(Service.AccessoryInformation);
         if (!informationService) {
@@ -1507,7 +1518,7 @@ eDomoticzAccessory.prototype = {
                     break;
                 }
 			case this.swTypeVal == Constants.DeviceTypeMedia:
-				{
+				{					
 					// TV control.
 					if(!this.mediaCommandMapping) {
 						this.mediaCommandMapping = {};
@@ -1542,8 +1553,8 @@ eDomoticzAccessory.prototype = {
 						.on('get', this.getActiveState.bind(this));
 					this.getCharacteristic(tvService, Characteristic.RemoteKey)
 						.on('set', this.sendTelevisionRemoteKey.bind(this));					
-					
-					// TV volume control.
+										
+					// TV volume.
 					var tvSpeakerService = this.getService(Service.TelevisionSpeaker);
                     if (!tvSpeakerService) {
                         tvSpeakerService = new Service.TelevisionSpeaker(this.name + ' - Volume', 'tvSpeakerService')
@@ -1561,7 +1572,7 @@ eDomoticzAccessory.prototype = {
 						.on('get', this.getTelevisionMuteState.bind(this));
 					tvService.addLinkedService(tvSpeakerService);
 					this.services.push(tvSpeakerService);
-					
+										
 					// TV input sources
 					tvService.setCharacteristic(Characteristic.ActiveIdentifier, 0);
 					tvService
@@ -1601,7 +1612,7 @@ eDomoticzAccessory.prototype = {
 							.setCharacteristic(Characteristic.InputSourceType, inputType);
 						tvService.addLinkedService(inputService);
 					});
-					
+										
 					this.services.push(tvService);					
 					break;
 				}

--- a/lib/domoticz_accessory.js
+++ b/lib/domoticz_accessory.js
@@ -38,7 +38,7 @@ function eDomoticzAccessory(platform, platformAccessory, IsScene, status, idx, n
     default:
         break;
     }
-
+	
     this.Type = Type;
     this.batteryRef = batteryRef;
     this.CounterToday = 1;
@@ -136,21 +136,21 @@ eDomoticzAccessory.prototype = {
 
         return service.addCharacteristic(new characteristicType());
     },
-    setPowerState: function (powerOn, callback, context) {
-        if ((context && context == "eDomoticz-MQTT") || (this.cachedValues[Characteristic.On.UUID] == powerOn && powerOn)) {
+    setPowerState: function (powerOn, callback, context, characteristic=Characteristic.On) {
+        if ((context && context == "eDomoticz-MQTT") || (this.cachedValues[characteristic.UUID] == powerOn && powerOn)) {
             callback();
             return;
         }
 
-        this.cachedValues[Characteristic.On.UUID] = powerOn;
+        this.cachedValues[characteristic.UUID] = powerOn;
         Domoticz.updateDeviceStatus(this, "switchlight", {
             "switchcmd": (powerOn ? "On" : "Off")
         }, function (success) {
             callback();
         }.bind(this));
     },
-    getPowerState: function (callback) {
-        var cachedValue = this.cachedValues[Characteristic.On.UUID];
+    getPowerState: function (callback, characteristic=Characteristic.On) {
+        var cachedValue = this.cachedValues[characteristic.UUID];
         if (cachedValue) {
             callback(null, cachedValue);
         }
@@ -170,8 +170,14 @@ eDomoticzAccessory.prototype = {
                 callback(null, value);
             }
 
-            this.cachedValues[Characteristic.On.UUID] = value;
+            this.cachedValues[characteristic.UUID] = value;
         }.bind(this));
+    },
+	setActiveState: function (state, callback, context) {
+        this.setPowerState(state, callback, context, Characteristic.Active);
+    },
+    getActiveState: function (callback) {
+		this.getPowerState(callback, Characteristic.Active);
     },
     getRainfall: function (callback) {
         Domoticz.deviceStatus(this, function (json) {
@@ -807,6 +813,33 @@ eDomoticzAccessory.prototype = {
             callback(null, value);
         }.bind(this));
     },
+	sendTelevisionRemoteKey: function (key, callback) {			
+		if(this.mediaCommandMapping && key in this.mediaCommandMapping) {
+			Domoticz.updateDeviceStatus(this, "kodimediacommand", {
+				"action": this.mediaCommandMapping[key],
+			}, function (success) {
+				callback();
+			}.bind(this));
+		} else {
+			callback(new Error("Unsupported remote key!"));
+		}
+	},
+	setTelevisionVolume: function (command, callback) {
+		this.platform.log("setTelevisionVolume: " + command);
+		callback(null);
+	},
+	setTelevisionMuteState: function (state, callback) {
+		// TODO
+		callback();
+	},
+	getTelevisionMuteState: function (callback) {
+		// TODO
+		callback();
+	},
+	setActiveIdentifier: function (identifier, callback) {
+		this.platform.log("setActiveIdentifier: " + identifier);
+		callback(null);
+	},
     handleMQTTMessage: function (message, callback) {
         this.platform.log("MQTT Message received for %s.\nName:\t\t%s\nDevice:\t\t%s,%s\nIs Switch:\t%s\nSwitchTypeVal:\t%s\nMQTT Message:\n%s", this.name, this.name, this.Type, this.subType, this.isSwitch, this.swTypeVal, JSON.stringify(message, null, 4));
 
@@ -866,8 +899,7 @@ eDomoticzAccessory.prototype = {
                     callback(characteristic, message.nvalue);
                     break;
                 }
-            case this.swTypeVal == Constants.DeviceTypeDimmer:
-            case this.swTypeVal == Constants.DeviceTypeMedia:
+            case this.swTypeVal == Constants.DeviceTypeDimmer:            
                 {
                     var isFan = this.image && this.image.indexOf("Fan") > -1
                     var service = this.getService(isFan ? Service.Fan : Service.Lightbulb);
@@ -911,6 +943,20 @@ eDomoticzAccessory.prototype = {
                     }
                     break;
                 }
+			case this.swTypeVal == Constants.DeviceTypeMedia:
+				{
+					var tvService = this.getService(Service.Television);
+					var tvSpeakerService = this.getService(Service.TelevisionSpeaker);
+
+                    var activeCharacteristic = this.getCharacteristic(tvService, Characteristic.Active);
+                    var isActive = (message.nvalue > 0);
+                    var wasActive = this.cachedValues[Characteristic.Active.UUID];
+                    if (message.svalue1 == 0 || isActive != wasActive) {
+                        callback(activeCharacteristic, isActive);
+                        this.cachedValues[Characteristic.Active.UUID] = isActive;
+                    }
+					break;
+				}
             case this.swTypeVal == Constants.DeviceTypeMotion:
                 {
                     var service = this.getService(Service.MotionSensor);
@@ -1359,6 +1405,8 @@ eDomoticzAccessory.prototype = {
         }
     },
     getServices: function () {
+		this.platform.log("getServices");
+
         this.services = [];
         var informationService = this.getService(Service.AccessoryInformation);
         if (!informationService) {
@@ -1377,7 +1425,7 @@ eDomoticzAccessory.prototype = {
             switch (true) {
             case this.swTypeVal == Constants.DeviceTypeSwitch || this.swTypeVal == Constants.DeviceTypePushOn:
                 {
-
+					this.platform.log("SWITCH: " + this.name);
                     var service = false;
                     if (this.image !== undefined && this.swTypeVal !== Constants.DeviceTypePushOn) {
                         if (this.image.indexOf("Fan") > -1) {
@@ -1436,14 +1484,13 @@ eDomoticzAccessory.prototype = {
                     break;
                 }
             case this.swTypeVal == Constants.DeviceTypeDimmer:
-            case this.swTypeVal == Constants.DeviceTypeMedia:
                 {
                     var isFan = this.image && this.image.indexOf("Fan") > -1
                     var service = this.getService(isFan ? Service.Fan : Service.Lightbulb);
                     if (!service) {
                         service = isFan ? new Service.Fan(this.name) : new Service.Lightbulb(this.name);
                     }
-                    this.getCharacteristic(service, Characteristic.On).on('set', this.setPowerState.bind(this)).on('get', this.getPowerState.bind(this));
+                    this.getCharacteristic(service, Characteristic.On).on('set', this.setPowerState.bind(this)).on('get', this.ferState.bind(this));
                     if (isFan) {
                         service.getCharacteristic(Characteristic.RotationSpeed).setProps({
                             minValue: 0,
@@ -1459,6 +1506,105 @@ eDomoticzAccessory.prototype = {
                     this.services.push(service);
                     break;
                 }
+			case this.swTypeVal == Constants.DeviceTypeMedia:
+				{
+					// TV control.
+					if(!this.mediaCommandMapping) {
+						this.mediaCommandMapping = {};
+						this.mediaCommandMapping[Characteristic.RemoteKey.REWIND] = 'Rewind';
+						this.mediaCommandMapping[Characteristic.RemoteKey.FAST_FORWARD] = 'FastForward';
+						this.mediaCommandMapping[Characteristic.RemoteKey.NEXT_TRACK] = 'BigStepForward';
+						this.mediaCommandMapping[Characteristic.RemoteKey.PREVIOUS_TRACK] = 'BigStepBack';
+						this.mediaCommandMapping[Characteristic.RemoteKey.ARROW_UP] = 'Up';
+						this.mediaCommandMapping[Characteristic.RemoteKey.ARROW_DOWN] = 'Down';
+						this.mediaCommandMapping[Characteristic.RemoteKey.ARROW_LEFT] = 'Left';
+						this.mediaCommandMapping[Characteristic.RemoteKey.ARROW_RIGHT] = 'Right';
+						this.mediaCommandMapping[Characteristic.RemoteKey.SELECT] = 'Select';
+						this.mediaCommandMapping[Characteristic.RemoteKey.BACK] = 'Back';
+						this.mediaCommandMapping[Characteristic.RemoteKey.EXIT] = 'Back';
+						this.mediaCommandMapping[Characteristic.RemoteKey.PLAY_PAUSE] = 'PlayPause';
+						this.mediaCommandMapping[Characteristic.RemoteKey.INFORMATION] = 'Info';
+					}					
+					
+					var tvService = this.getService(Service.Television, 'tvService');
+                    if (!tvService) {
+                        tvService = new Service.Television(this.name)						
+                    }			
+					tvService
+					.setCharacteristic(Characteristic.ConfiguredName, this.name)
+					.setCharacteristic(Characteristic.Active, Characteristic.Active.ACTIVE)
+					.setCharacteristic(
+						Characteristic.SleepDiscoveryMode,
+						Characteristic.SleepDiscoveryMode.ALWAYS_DISCOVERABLE
+					);
+					this.getCharacteristic(tvService, Characteristic.Active)
+						.on('set', this.setActiveState.bind(this))
+						.on('get', this.getActiveState.bind(this));
+					this.getCharacteristic(tvService, Characteristic.RemoteKey)
+						.on('set', this.sendTelevisionRemoteKey.bind(this));					
+					
+					// TV volume control.
+					var tvSpeakerService = this.getService(Service.TelevisionSpeaker);
+                    if (!tvSpeakerService) {
+                        tvSpeakerService = new Service.TelevisionSpeaker(this.name + ' - Volume', 'tvSpeakerService')
+                    }
+					tvSpeakerService
+						.setCharacteristic(Characteristic.Active, Characteristic.Active.ACTIVE)
+						.setCharacteristic(
+							Characteristic.VolumeControlType,
+							Characteristic.VolumeControlType.RELATIVE
+						);
+					this.getCharacteristic(tvSpeakerService, Characteristic.VolumeSelector)
+						.on('set', this.setTelevisionVolume.bind(this));
+					this.getCharacteristic(tvSpeakerService, Characteristic.Mute)
+						.on('set', this.setTelevisionMuteState.bind(this))
+						.on('get', this.getTelevisionMuteState.bind(this));
+					tvService.addLinkedService(tvSpeakerService);
+					this.services.push(tvSpeakerService);
+					
+					// TV input sources
+					tvService.setCharacteristic(Characteristic.ActiveIdentifier, 0);
+					tvService
+						.getCharacteristic(Characteristic.ActiveIdentifier)
+						.on('set', this.setActiveIdentifier.bind(this));
+					
+					var inputs = ["TV", "HDMI1", "HDMI2", "NPO", "Netflix"]; // TODO: retrieve from Domoticz.
+					
+					inputs.forEach((input, index) => {						
+						var inputType;
+						switch (true) {
+							case input.match(/hdmi/i):
+								inputType = Characteristic.InputSourceType.HDMI;
+								break;
+							case input.match(/ypbpr/i):
+								inputType = Characteristic.InputSourceType.COMPONENT_VIDEO;
+								break;							
+							default:
+								inputType = Characteristic.InputSourceType.OTHER;
+								break;
+						}
+						
+						var inputService = new Service.InputSource(
+							input,
+							input.toUpperCase()
+						);
+						inputService
+							.setCharacteristic(Characteristic.Identifier, index)
+							.setCharacteristic(
+								Characteristic.ConfiguredName,
+								input.toUpperCase()
+							)
+							.setCharacteristic(
+								Characteristic.IsConfigured,
+								Characteristic.IsConfigured.CONFIGURED
+							)
+							.setCharacteristic(Characteristic.InputSourceType, inputType);
+						tvService.addLinkedService(inputService);
+					});
+					
+					this.services.push(tvService);					
+					break;
+				}
             case this.swTypeVal == Constants.DeviceTypeSelector:
                 {
                     var selectorService = this.getService(Service.StatelessProgrammableSwitch);

--- a/lib/domoticz_accessory.js
+++ b/lib/domoticz_accessory.js
@@ -85,7 +85,7 @@ eDomoticzAccessory.prototype = {
             var service = services[i];
 
             var existingService = this.platformAccessory.services.find(function (eService) {
-                return eService.UUID == service.UUID;
+                return eService.UUID == service.UUID && eService.subtype == service.subtype;
             });
 
             if (!existingService) {
@@ -104,7 +104,7 @@ eDomoticzAccessory.prototype = {
         if (!service) {
             var targetService = new name();
             service = this.platformAccessory.services.find(function (existingService) {
-                return existingService.UUID == targetService.UUID;
+                return existingService.UUID == targetService.UUID && existingService.subtype == targetService.subtype;
             });
         }
 
@@ -122,7 +122,7 @@ eDomoticzAccessory.prototype = {
         if (!characteristic) {
             var targetCharacteristic = new name();
             characteristic = service.characteristics.find(function (existingCharacteristic) {
-                return existingCharacteristic.UUID == targetCharacteristic.UUID;
+                return existingCharacteristic.UUID == targetCharacteristic.UUID && existingCharacteristic.subtype == targetCharacteristic.subtype;
             });
         }
 
@@ -962,11 +962,11 @@ eDomoticzAccessory.prototype = {
 					var tvSpeakerService = this.getService(Service.TelevisionSpeaker);
 
                     var activeCharacteristic = this.getCharacteristic(tvService, Characteristic.Active);
-                    var isActive = (message.nvalue > 0);
-                    var wasActive = this.cachedValues[Characteristic.Active.UUID];
-                    if (message.svalue1 == 0 || isActive != wasActive) {
-                        callback(activeCharacteristic, isActive);
-                        this.cachedValues[Characteristic.Active.UUID] = isActive;
+                    var state = (message.nvalue > 0) ? Characteristic.Active.ACTIVE : Characteristic.Active.INACTIVE;
+                    var oldState = this.cachedValues[Characteristic.Active.UUID];
+                    if (message.svalue1 == 0 || state != oldState) {
+                        callback(activeCharacteristic, state);
+                        this.cachedValues[Characteristic.Active.UUID] = state;
                     }
 					break;
 				}
@@ -1436,7 +1436,6 @@ eDomoticzAccessory.prototype = {
             switch (true) {
             case this.swTypeVal == Constants.DeviceTypeSwitch || this.swTypeVal == Constants.DeviceTypePushOn:
                 {
-					this.platform.log("SWITCH: " + this.name);
                     var service = false;
                     if (this.image !== undefined && this.swTypeVal !== Constants.DeviceTypePushOn) {
                         if (this.image.indexOf("Fan") > -1) {
@@ -1539,32 +1538,25 @@ eDomoticzAccessory.prototype = {
 					
 					var tvService = this.getService(Service.Television, 'tvService');
                     if (!tvService) {
-                        tvService = new Service.Television(this.name)						
+                        tvService = new Service.Television(this.name);
                     }			
 					tvService
 					.setCharacteristic(Characteristic.ConfiguredName, this.name)
-					.setCharacteristic(Characteristic.Active, Characteristic.Active.ACTIVE)
-					.setCharacteristic(
-						Characteristic.SleepDiscoveryMode,
-						Characteristic.SleepDiscoveryMode.ALWAYS_DISCOVERABLE
-					);
+					.setCharacteristic(Characteristic.SleepDiscoveryMode, Characteristic.SleepDiscoveryMode.ALWAYS_DISCOVERABLE);
 					this.getCharacteristic(tvService, Characteristic.Active)
 						.on('set', this.setActiveState.bind(this))
 						.on('get', this.getActiveState.bind(this));
 					this.getCharacteristic(tvService, Characteristic.RemoteKey)
 						.on('set', this.sendTelevisionRemoteKey.bind(this));					
-										
+					this.services.push(tvService);
+					
 					// TV volume.
 					var tvSpeakerService = this.getService(Service.TelevisionSpeaker);
                     if (!tvSpeakerService) {
-                        tvSpeakerService = new Service.TelevisionSpeaker(this.name + ' - Volume', 'tvSpeakerService')
+                        tvSpeakerService = new Service.TelevisionSpeaker(this.name + ' volume', 'tvSpeakerService');
                     }
 					tvSpeakerService
-						.setCharacteristic(Characteristic.Active, Characteristic.Active.ACTIVE)
-						.setCharacteristic(
-							Characteristic.VolumeControlType,
-							Characteristic.VolumeControlType.RELATIVE
-						);
+						.setCharacteristic(Characteristic.VolumeControlType, Characteristic.VolumeControlType.RELATIVE);
 					this.getCharacteristic(tvSpeakerService, Characteristic.VolumeSelector)
 						.on('set', this.setTelevisionVolume.bind(this));
 					this.getCharacteristic(tvSpeakerService, Characteristic.Mute)
@@ -1579,11 +1571,14 @@ eDomoticzAccessory.prototype = {
 						.getCharacteristic(Characteristic.ActiveIdentifier)
 						.on('set', this.setActiveIdentifier.bind(this));
 					
-					var inputs = ["TV", "HDMI1", "HDMI2", "NPO", "Netflix"]; // TODO: retrieve from Domoticz.
+					var inputs = ["Live", "HDMI1", "HDMI2", "NPO", "Netflix"]; // TODO: retrieve from Domoticz.
 					
 					inputs.forEach((input, index) => {						
 						var inputType;
 						switch (true) {
+							case input.match(/^TV|Live$/i):
+								inputType = Characteristic.InputSourceType.TUNER;
+								break;								 
 							case input.match(/hdmi/i):
 								inputType = Characteristic.InputSourceType.HDMI;
 								break;
@@ -1591,29 +1586,21 @@ eDomoticzAccessory.prototype = {
 								inputType = Characteristic.InputSourceType.COMPONENT_VIDEO;
 								break;							
 							default:
-								inputType = Characteristic.InputSourceType.OTHER;
+								inputType = Characteristic.InputSourceType.APPLICATION;
 								break;
 						}
-						
-						var inputService = new Service.InputSource(
-							input,
-							input.toUpperCase()
-						);
+											
+						var inputService = new Service.InputSource(input.replace(/\s/g, '').toLowerCase(), input);
 						inputService
-							.setCharacteristic(Characteristic.Identifier, index)
-							.setCharacteristic(
-								Characteristic.ConfiguredName,
-								input.toUpperCase()
-							)
-							.setCharacteristic(
-								Characteristic.IsConfigured,
-								Characteristic.IsConfigured.CONFIGURED
-							)
-							.setCharacteristic(Characteristic.InputSourceType, inputType);
+							.setCharacteristic(Characteristic.Identifier, index + 1)
+							.setCharacteristic(Characteristic.ConfiguredName, input)
+							.setCharacteristic(Characteristic.IsConfigured, Characteristic.IsConfigured.CONFIGURED)
+							.setCharacteristic(Characteristic.InputSourceType, inputType)
+							.setCharacteristic(Characteristic.CurrentVisibilityState, Characteristic.CurrentVisibilityState.SHOWN);
 						tvService.addLinkedService(inputService);
+						this.services.push(inputService);
 					});
-										
-					this.services.push(tvService);					
+									
 					break;
 				}
             case this.swTypeVal == Constants.DeviceTypeSelector:

--- a/lib/domoticz_accessory.js
+++ b/lib/domoticz_accessory.js
@@ -2076,5 +2076,16 @@ eDomoticzAccessory.prototype = {
 				});						
 			}.bind(this));
 		}.bind(this));
+	},
+	removed: function() { // This accessory has been removed.		
+		var tvAccessoriesIndex = tvAccessories.indexOf(this);
+		if (tvAccessoriesIndex !== -1) {
+			tvAccessories.splice(tvAccessoriesIndex, 1);
+		}
+		
+		var tvInputAccessoriesIndex = tvInputAccessories.indexOf(this);
+		if (tvInputAccessoriesIndex !== -1) {
+			tvInputAccessories.splice(tvInputAccessoriesIndex, 1);
+		}
 	}
 };

--- a/lib/domoticz_accessory.js
+++ b/lib/domoticz_accessory.js
@@ -870,17 +870,18 @@ eDomoticzAccessory.prototype = {
             callback(null, value);
         }.bind(this));
 	},
-	setActiveIdentifier: function (identifier, callback) {
-		if (identifier > 0) {
-			Domoticz.updateDeviceStatus(this, "switchlight", {
-				"switchcmd": "Set Level",
-				"level": identifier * 10
-			}, function (success) {
-				callback(null, identifier);
-			}.bind(this));
-		} else {
+	setActiveIdentifier: function (identifier, callback, context) {
+		if ((context && context == "eDomoticz-MQTT") || identifier == 0) {
+            callback();
+            return;
+        }
+		
+		Domoticz.updateDeviceStatus(this, "switchlight", {
+			"switchcmd": "Set Level",
+			"level": identifier * 10
+		}, function (success) {
 			callback(null, identifier);
-		}			
+		}.bind(this));	
 	},
 	getActiveIdentifier: function (callback) {
 		Domoticz.deviceStatus(this, function (json) {

--- a/lib/domoticz_accessory.js
+++ b/lib/domoticz_accessory.js
@@ -1086,7 +1086,7 @@ eDomoticzAccessory.prototype = {
                     var characteristic = this.getCharacteristic(tvService, Characteristic.ActiveIdentifier);
                     var identifier = parseInt(message.svalue1) / 10;
                     var oldIdentifier = this.cachedValues[Characteristic.ActiveIdentifier.UUID];
-                    
+					
                     if (identifier != oldIdentifier) {
                         this.cachedValues[Characteristic.ActiveIdentifier.UUID] = identifier;
                         callback(characteristic, identifier);

--- a/lib/domoticz_accessory.js
+++ b/lib/domoticz_accessory.js
@@ -861,36 +861,57 @@ eDomoticzAccessory.prototype = {
         }.bind(this));
     },
     getTelevisionMuteState: function (callback) {
+        var cachedValue = this.cachedValues[Characteristic.Mute.UUID];
+        if (cachedValue) {
+            callback(null, cachedValue);
+        }
+        
         Domoticz.deviceStatus(this, function (json) {
             var value;
             var sArray = Helper.sortByKey(json.result, "Name");
             sArray.map(function (s) {
                 value = (s.Data.indexOf("(muted)") > -1);
             }.bind(this));
-            callback(null, value);
+            
+            if (!cachedValue) {
+                callback(null, value);
+            }
+            
+            this.cachedValues[Characteristic.Mute.UUID] = value;
         }.bind(this));
     },
     setActiveIdentifier: function (identifier, callback, context) {
-        if ((context && context == "eDomoticz-MQTT") || identifier == 0) {
+        if ((context && context == "eDomoticz-MQTT") || this.cachedValues[Characteristic.ActiveIdentifier.UUID] == identifier) {
             callback();
             return;
         }
         
+        this.cachedValues[Characteristic.ActiveIdentifier.UUID] = identifier;
         Domoticz.updateDeviceStatus(this, "switchlight", {
             "switchcmd": "Set Level",
             "level": identifier * 10
         }, function (success) {
-            callback(null, identifier);
+            callback();
         }.bind(this));    
     },
     getActiveIdentifier: function (callback) {
+        var cachedValue = this.cachedValues[Characteristic.ActiveIdentifier.UUID];
+        if (cachedValue) {
+            callback(null, cachedValue);
+        }
+        
         Domoticz.deviceStatus(this, function (json) {
             var value = 0;
             var sArray = Helper.sortByKey(json.result, "Name");
             sArray.map(function (s) {
                 value = s.Level / 10;
             }.bind(this));
-            callback(null, value);
+            
+            if (!cachedValue) {
+                callback(null, value);
+            }
+            
+            this.cachedValues[Characteristic.ActiveIdentifier.UUID] = value;
         }.bind(this));
     },
     handleMQTTMessage: function (message, callback) {
@@ -1064,7 +1085,12 @@ eDomoticzAccessory.prototype = {
                     var tvService = tvAccessories[this.hwType.toString()].getService(Service.Television);
                     var characteristic = this.getCharacteristic(tvService, Characteristic.ActiveIdentifier);
                     var identifier = parseInt(message.svalue1) / 10;
-                    callback(characteristic, identifier);
+                    var oldIdentifier = this.cachedValues[Characteristic.ActiveIdentifier.UUID];
+                    
+                    if (identifier != oldIdentifier) {
+                        this.cachedValues[Characteristic.ActiveIdentifier.UUID] = identifier;
+                        callback(characteristic, identifier);
+                    }
                 }
                 break;
             case this.swTypeVal == Constants.DeviceTypeDoorLock:
@@ -1598,11 +1624,14 @@ eDomoticzAccessory.prototype = {
                         tvService = new Service.Television(this.name);
                     }            
                     tvService
-                    .setCharacteristic(Characteristic.ConfiguredName, this.name)
-                    .setCharacteristic(Characteristic.SleepDiscoveryMode, Characteristic.SleepDiscoveryMode.ALWAYS_DISCOVERABLE);
+                        .setCharacteristic(Characteristic.ConfiguredName, this.name)
+                        .setCharacteristic(Characteristic.SleepDiscoveryMode, Characteristic.SleepDiscoveryMode.ALWAYS_DISCOVERABLE);
                     this.getCharacteristic(tvService, Characteristic.Active)
                         .on('set', this.setActiveState.bind(this))
-                        .on('get', this.getActiveState.bind(this));
+                        .on('get', this.getActiveState.bind(this));                        
+                    this.getCharacteristic(tvService, Characteristic.ActiveIdentifier)
+                        .on('set', this.setActiveIdentifier.bind(this))
+                        .on('get', this.getActiveIdentifier.bind(this));                                
                     this.getCharacteristic(tvService, Characteristic.RemoteKey)
                         .on('set', this.sendTelevisionRemoteKey.bind(this));                    
                     this.services.push(tvService);
@@ -2030,12 +2059,7 @@ eDomoticzAccessory.prototype = {
     },
     createTvInputService: function (domoticzInputSourceAccessory) {
         var tvService = this.services[1];
-        //tvService.setCharacteristic(Characteristic.ActiveIdentifier, 0);
-        tvService
-            .getCharacteristic(Characteristic.ActiveIdentifier)
-            .on('set', domoticzInputSourceAccessory.setActiveIdentifier.bind(domoticzInputSourceAccessory))
-            .on('get', domoticzInputSourceAccessory.getActiveIdentifier.bind(domoticzInputSourceAccessory));
-            
+                    
         Domoticz.deviceStatus(domoticzInputSourceAccessory, function (json) {
         var sArray = Helper.sortByKey(json.result, "Name");
             sArray.map(function (s) {
@@ -2074,19 +2098,16 @@ eDomoticzAccessory.prototype = {
                     if(this.published) {
                         this.publishService(inputService);
                     }
-                });                        
+                });
             }.bind(this));
         }.bind(this));
     },
-    removed: function() { // This accessory has been removed.        
-        var tvAccessoriesIndex = tvAccessories.indexOf(this);
-        if (tvAccessoriesIndex !== -1) {
-            tvAccessories.splice(tvAccessoriesIndex, 1);
+    removed: function() { // This accessory has been removed.
+        if (this.hwType.toString() in tvAccessories) {
+            delete tvAccessories[this.hwType.toString()];
         }
-        
-        var tvInputAccessoriesIndex = tvInputAccessories.indexOf(this);
-        if (tvInputAccessoriesIndex !== -1) {
-            tvInputAccessories.splice(tvInputAccessoriesIndex, 1);
+        if (this.hwType.toString() in tvInputAccessories) {
+            delete tvInputAccessories[this.hwType.toString()];
         }
     }
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-edomoticz",
-  "version": "2.1.13",
+  "version": "2.1.14",
   "description": "homebridge-plugin for Domoticz https://github.com/nfarina/homebridge",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/patchworkboy/homebridge-eDomoticz.git"
+    "url": "https://github.com/sander1988/homebridge-edomoticz.git"
   },
   "preferGlobal": true,
   "keywords": [


### PR DESCRIPTION
Adds television support for Domoticz SwitchTypeVal 17 devices. I just started testing it in my environment on my iPhone (iOS 13). Please feel free to leave any feedback or questions.

**A few notes:**
- Most Domoticz TV plugins use seperate devices for TV control and TV source / channel. This needs to be a combined device in HomeKit in order to work correctly. So I had to create a solution for this using the static _tvAccessories_ and _tvInputAccessories_ variables.
- The check for finding existing services (in functions like publishService, getService, etc.) did only check the UUID of devices. As far I understand the HomeKit specs it should also check the subtype. I have changed it in order to get the television part working.
- Televisions have an Active state (instead of a power state like for regular devices). I modified the existing power state functions to also support this Active characteristic.
- This change adds also support for controling your TV using HomeBridge. You have to launch the Apple TV widget (not the HomeKit app!) on your iOS device. This let's you control it.
- You can also change the volume of the TV. This is done using the **hardware** button on your iOS devices while the TV widget is open.
- I have added support for muting and unmuting. But I couldn't find a way to do this from my iPhone. Does anyone know how to do this?


