### PR TITLE
Encode Domoticz levels into UTF8 instead of ASCII

### DIFF
--- a/lib/domoticz_accessory.js
+++ b/lib/domoticz_accessory.js
@@ -2201,7 +2201,7 @@ eDomoticzAccessory.prototype = {
         Domoticz.deviceStatus(domoticzInputSourceAccessory, function (json) {
         var sArray = Helper.sortByKey(json.result, "Name");
             sArray.map(function (s) {
-                var inputs = new Buffer(s.LevelNames, 'base64').toString("ascii").split("|");
+                var inputs = new Buffer(s.LevelNames, 'base64').toString("utf8").split("|");
                 if(inputs.length > 0 && inputs[0] == "Off") {
                     inputs.shift();
                 }


### PR DESCRIPTION
Should always be UTF8 (as required by HomeKit specs).