### PR TITLE
Fixes power state (on/off) cache corruption.

### DIFF
--- a/lib/domoticz_accessory.js
+++ b/lib/domoticz_accessory.js
@@ -148,22 +148,22 @@ eDomoticzAccessory.prototype = {
 
         return service.addCharacteristic(new characteristicType());
     },
-    setPowerState: function (powerOn, callback, context, characteristic=Characteristic.On) {
-        if ((context && context == "eDomoticz-MQTT") || (this.cachedValues[characteristic.UUID] == powerOn && powerOn)) {
+    setPowerState: function (powerOn, callback, context) {        
+        if (context && context == "eDomoticz-MQTT") {
             callback();
             return;
         }
 
-        this.cachedValues[characteristic.UUID] = powerOn;
         Domoticz.updateDeviceStatus(this, "switchlight", {
             "switchcmd": (powerOn ? "On" : "Off")
         }, function (success) {
+            this.cachedValues[Characteristic.On.UUID] = powerOn;
             callback();
         }.bind(this));
     },
-    getPowerState: function (callback, characteristic=Characteristic.On) {
-        var cachedValue = this.cachedValues[characteristic.UUID];
-        if (cachedValue) {
+    getPowerState: function (callback) {        
+        var cachedValue = this.cachedValues[Characteristic.On.UUID];
+        if (typeof cachedValue !== 'undefined') {
             callback(null, cachedValue);
         }
 
@@ -172,25 +172,51 @@ eDomoticzAccessory.prototype = {
             var sArray = Helper.sortByKey(json.result, "Name");
             sArray.map(function (s) {
                 if (this.swTypeVal == Constants.DeviceTypePushOn) {
-                    value = (s.Data == "Off") ? !1 : !0;
+                    value = (s.Data == "Off") ? false : true;
                 } else {
-                    value = (s.Status == "Off") ? 0 : 1;
+                    value = (s.Status == "Off") ? false : true;
                 }
             }.bind(this));
-
-            if (!cachedValue) {
+            
+            if (typeof cachedValue === 'undefined') {
                 callback(null, value);
             }
 
-            this.cachedValues[characteristic.UUID] = value;
+            this.cachedValues[Characteristic.On.UUID] = value;
         }.bind(this));
     },
     setActiveState: function (state, callback, context) {
-        this.setPowerState(state, callback, context, Characteristic.Active);
+        if (context && context == "eDomoticz-MQTT") {
+            callback();
+            return;
+        }
+
+        Domoticz.updateDeviceStatus(this, "switchlight", {
+            "switchcmd": (state ? "On" : "Off")
+        }, function (success) {
+            this.cachedValues[Characteristic.Active.UUID] = state;
+            callback();
+        }.bind(this));
     },
     getActiveState: function (callback) {
-        this.getPowerState(callback, Characteristic.Active);
-    },
+        var cachedValue = this.cachedValues[Characteristic.Active.UUID];
+        if (typeof cachedValue !== 'undefined') {
+            callback(null, cachedValue);
+        }
+
+        Domoticz.deviceStatus(this, function (json) {
+            var value;
+            var sArray = Helper.sortByKey(json.result, "Name");
+            sArray.map(function (s) {
+                value = (s.Status == "Off") ? false : true;
+            }.bind(this));
+            
+            if (typeof cachedValue === 'undefined') {
+                callback(null, value);
+            }
+
+            this.cachedValues[Characteristic.Active.UUID] = value;
+        }.bind(this));    },
     getRainfall: function (callback) {
         Domoticz.deviceStatus(this, function (json) {
             var value;
@@ -228,7 +254,7 @@ eDomoticzAccessory.prototype = {
     },
     getdValue: function (callback) {
         var cachedValue = (this.isPercentageBlind || this.isInvertedBlind) ? this.cachedValues[Characteristic.CurrentPosition.UUID] : this.cachedValues[Characteristic.Brightness.UUID];
-        if (cachedValue) {
+        if (typeof cachedValue !== 'undefined') {
             callback(null, cachedValue);
         }
 
@@ -241,7 +267,7 @@ eDomoticzAccessory.prototype = {
             }.bind(this));
             this.platform.log("Data Received for " + this.name + ": " + value);
 
-            if (!cachedValue) {
+            if (typeof cachedValue === 'undefined') {
                 callback(null, value);
             }
 
@@ -783,7 +809,7 @@ eDomoticzAccessory.prototype = {
     },
     getSecuritySystemStatus: function (callback) {
         var cachedValue = this.cachedValues[Characteristic.SecuritySystemCurrentState.UUID];
-        if (cachedValue) {
+        if (typeof cachedValue !== 'undefined') {
             callback(null, cachedValue);
         }
 
@@ -807,7 +833,7 @@ eDomoticzAccessory.prototype = {
                 }
             }.bind(this));
 
-            if (!cachedValue) {
+            if (typeof cachedValue === 'undefined') {
                 callback(null, value);
             }
 
@@ -907,22 +933,22 @@ eDomoticzAccessory.prototype = {
             callback();
         }.bind(this));
     },
-    setTelevisionMuteState: function (state, callback) {
-        if (this.cachedValues[Characteristic.Mute.UUID] == state) {
+    setTelevisionMuteState: function (state, callback, context) {
+        if (context && context == "eDomoticz-MQTT") {
             callback();
             return;
         }
 
-        this.cachedValues[Characteristic.Mute.UUID] = state;
         Domoticz.updateDeviceStatus(this, "kodimediacommand", {
             "action": "Mute",
         }, function (success) {
+            this.cachedValues[Characteristic.Mute.UUID] = state;
             callback();
         }.bind(this));
     },
     getTelevisionMuteState: function (callback) {
         var cachedValue = this.cachedValues[Characteristic.Mute.UUID];
-        if (cachedValue) {
+        if (typeof cachedValue !== 'undefined') {
             callback(null, cachedValue);
         }
 
@@ -933,7 +959,7 @@ eDomoticzAccessory.prototype = {
                 value = (s.Data.indexOf("(muted)") > -1);
             }.bind(this));
 
-            if (!cachedValue) {
+            if (typeof cachedValue === 'undefined') {
                 callback(null, value);
             }
 
@@ -941,27 +967,24 @@ eDomoticzAccessory.prototype = {
         }.bind(this));
     },
     setActiveIdentifier: function (identifier, callback, context) {
-        if ((context && context == "eDomoticz-MQTT") || this.cachedValues[Characteristic.ActiveIdentifier.UUID] == identifier) {
+        if (context && context == "eDomoticz-MQTT") {
             callback();
             return;
         }
         
-        this.cachedValues[Characteristic.ActiveIdentifier.UUID] = identifier;
-
         if (this.hwId.toString() in tvInputAccessories) {
             Domoticz.updateDeviceStatus(tvInputAccessories[this.hwId.toString()], "switchlight", {
                 "switchcmd": "Set Level",
                 "level": identifier * 10
             }, function (success) {
+                this.cachedValues[Characteristic.ActiveIdentifier.UUID] = identifier;
                 callback();
             }.bind(this));
-        } else {
-            callback();
         }
     },
     getActiveIdentifier: function (callback) {
         var cachedValue = this.cachedValues[Characteristic.ActiveIdentifier.UUID];
-        if (cachedValue) {
+        if (typeof cachedValue !== 'undefined') {
             callback(null, cachedValue);
         }
 
@@ -973,13 +996,13 @@ eDomoticzAccessory.prototype = {
                     value = s.Level / 10;
                 }.bind(this));
 
-                if (!cachedValue) {
+                if (typeof cachedValue === 'undefined') {
                     callback(null, value);
                 }
 
                 this.cachedValues[Characteristic.ActiveIdentifier.UUID] = value;
             }.bind(this));
-        } else if (!cachedValue) {
+        } else if (typeof cachedValue === 'undefined') {
             this.cachedValues[Characteristic.ActiveIdentifier.UUID] = 0;
             callback(null, 0);
         } 
@@ -996,10 +1019,7 @@ eDomoticzAccessory.prototype = {
         if (this.isSwitch) {
             switch (true) {
             case this.swTypeVal == Constants.DeviceTypeSwitch || this.swTypeVal == Constants.DeviceTypePushOn:
-                {
-                    this.cachedValues[Characteristic.On.UUID] = message.nvalue;
-
-
+                {                    
                     var service = false;
                     if (this.image !== undefined && this.swTypeVal !== Constants.DeviceTypePushOn) {
                         if (this.image.indexOf("Fan") > -1) {
@@ -1017,15 +1037,16 @@ eDomoticzAccessory.prototype = {
                         }
                     } else {
                         service = this.getService(Service.Switch);
-
                     }
 
                     if (!service) {
                         break;
                     }
 
+                    var powerOn = (message.nvalue > 0);
+                    this.cachedValues[Characteristic.On.UUID] = powerOn;
                     var characteristic = this.getCharacteristic(service, Characteristic.On);
-                    callback(characteristic, message.nvalue);
+                    callback(characteristic, powerOn);
                     break;
                 }
             case this.swTypeVal == Constants.DeviceTypeContact:
@@ -1160,7 +1181,6 @@ eDomoticzAccessory.prototype = {
 
                     if (identifier != oldIdentifier) {
                         tvAccessory.cachedValues[Characteristic.ActiveIdentifier.UUID] = identifier;
-                        this.platform.log("TV identifier cached updated (1) for idx: " + tvAccessory.idx + " to: " + identifier);
                         callback(characteristic, identifier);
                     }
                 }
@@ -1754,7 +1774,7 @@ eDomoticzAccessory.prototype = {
                         .on('set', this.sendTelevisionRemoteKey.bind(this));
                     this.services.push(tvService);
                     tvAccessories[this.hwId.toString()] = this;
-
+                    
                     // TV volume.
                     var tvSpeakerService = this.getService(Service.TelevisionSpeaker);
                     if (!tvSpeakerService) {
@@ -1769,11 +1789,11 @@ eDomoticzAccessory.prototype = {
                         .on('get', this.getTelevisionMuteState.bind(this));
                     tvService.addLinkedService(tvSpeakerService);
                     this.services.push(tvSpeakerService);
-
+                    
                     if (this.hwId.toString() in tvInputAccessories) {
                         this.createTvInputService(tvInputAccessories[this.hwId.toString()]);
-                    }
-
+                    }                   
+                 
                     break;
                 }
             case this.swTypeVal == Constants.DeviceTypeSelector && this.image == "TV":


### PR DESCRIPTION
**Changes:**
- Power on/off as boolean instead of int (the HomeKit specs say it should be a bool).
- Cached value used check changed to 'undefined' checks as they didn't work correctly with bools. "if (!cachedValue)" is also true for a false or 0 value.
- Updated the device value cache only after successful Domoticz calls.
- Always update the characteristic in their setters (even if they seem unchanged). Let HomeBridge handle the check if it should be processed to HomeKit.