### PR TITLE
Homebridge 2.x / HAP-NodeJS v2 compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,9 @@ var Mqtt = require('./lib/mqtt.js').Mqtt;
 var eDomoticzAccessory = require('./lib/domoticz_accessory.js');
 var Constants = require('./lib/constants.js');
 var Helper = require('./lib/helper.js').Helper;
-var eDomoticzServices = require('./lib/services.js').eDomoticzServices;
+var Services = require('./lib/services.js');
+var eDomoticzServices = Services.eDomoticzServices;
+var initServices = Services.initServices;
 const util = require('util');
 
 module.exports = function(homebridge) {
@@ -24,40 +26,11 @@ module.exports = function(homebridge) {
     Types = homebridge.hapLegacyTypes;
     UUID = homebridge.hap.uuid;
 
-    util.inherits(eDomoticzServices.TotalConsumption, Characteristic);
-    util.inherits(eDomoticzServices.CurrentConsumption, Characteristic);
-    util.inherits(eDomoticzServices.GasConsumption, Characteristic);
-    util.inherits(eDomoticzServices.TempOverride, Characteristic);
-    util.inherits(eDomoticzServices.MeterDeviceService, Service);
-    util.inherits(eDomoticzServices.GasDeviceService, Service);
-    util.inherits(eDomoticzServices.Ampere, Characteristic);
-    util.inherits(eDomoticzServices.AMPDeviceService, Service);
-    util.inherits(eDomoticzServices.Volt, Characteristic);
-    util.inherits(eDomoticzServices.VOLTDeviceService, Service);
-    util.inherits(eDomoticzServices.CurrentUsage, Characteristic);
-    util.inherits(eDomoticzServices.UsageDeviceService, Service);
-    util.inherits(eDomoticzServices.TodayConsumption, Characteristic);
-    util.inherits(eDomoticzServices.Barometer, Characteristic);
-    util.inherits(eDomoticzServices.WaterFlow, Characteristic);
-    util.inherits(eDomoticzServices.TotalWaterFlow, Characteristic);
-    util.inherits(eDomoticzServices.WaterDeviceService, Service);
-    util.inherits(eDomoticzServices.WeatherService, Service);
-    util.inherits(eDomoticzServices.WindSpeed, Characteristic);
-    util.inherits(eDomoticzServices.WindChill, Characteristic);
-    util.inherits(eDomoticzServices.WindDirection, Characteristic);
-    util.inherits(eDomoticzServices.WindDeviceService, Service);
-    util.inherits(eDomoticzServices.Rainfall, Characteristic);
-    util.inherits(eDomoticzServices.RainDeviceService, Service);
-    util.inherits(eDomoticzServices.Visibility, Characteristic);
-    util.inherits(eDomoticzServices.VisibilityDeviceService, Service);
-    util.inherits(eDomoticzServices.SolRad, Characteristic);
-    util.inherits(eDomoticzServices.SolRadDeviceService, Service);
-    util.inherits(eDomoticzServices.LocationService, Service);
-    util.inherits(eDomoticzServices.Location, Characteristic);
-    util.inherits(eDomoticzServices.InfotextDeviceService, Service);
-    util.inherits(eDomoticzServices.Infotext, Characteristic);
-    util.inherits(eDomoticzServices.UVDeviceService, Service);
-    util.inherits(eDomoticzServices.UVIndex, Characteristic);
+    // Populate eDomoticzServices with ES6 class definitions now that HAP refs
+    // (Service / Characteristic) are available. Replaces the previous pattern
+    // of pre-ES6 constructors + util.inherits, which crashes under HAP-NodeJS
+    // v2 ("Class constructor Service cannot be invoked without 'new'").
+    initServices(Service, Characteristic, UUID);
 
     //homebridge.registerAccessory("homebridge-edomoticz", "eDomoticz", eDomoticzAccessory);
     homebridge.registerPlatform("homebridge-edomoticz", "eDomoticz", eDomoticzPlatform, true);

--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ module.exports = function(homebridge) {
     // (Service / Characteristic) are available. Replaces the previous pattern
     // of pre-ES6 constructors + util.inherits, which crashes under HAP-NodeJS
     // v2 ("Class constructor Service cannot be invoked without 'new'").
-    initServices(Service, Characteristic, UUID);
+    initServices(Service, Characteristic, UUID, homebridge.hap);
 
     //homebridge.registerAccessory("homebridge-edomoticz", "eDomoticz", eDomoticzAccessory);
     homebridge.registerPlatform("homebridge-edomoticz", "eDomoticz", eDomoticzPlatform, true);

--- a/lib/domoticz.js
+++ b/lib/domoticz.js
@@ -48,7 +48,6 @@ Domoticz.settings = function(accessory, completion, error) {
       Helper.LogConnectionError(this.platform, response, err);
       if (typeof error !== 'undefined' && error !== false) {
         error();
-        callback();
       }
     }
   }.bind(accessory));
@@ -208,7 +207,6 @@ Domoticz.updateWithURL = function(accessory, url, completion) {
     }
     else {
       Helper.LogConnectionError(this.platform, response, err);
-      callback();
     }
 
     if (typeof completion !== 'undefined' && completion !== false) {

--- a/lib/services.js
+++ b/lib/services.js
@@ -17,7 +17,23 @@ module.exports = {
  * Order matters per the migration plan: define the 20 custom Characteristics
  * first, then the 14 custom Services that compose them.
  */
-function initServices(Service, Characteristic, UUID) {
+function initServices(Service, Characteristic, UUID, hap) {
+
+    // HAP-NodeJS v1 exposed Formats / Perms / Units as static enums on the
+    // Characteristic class. HAP-NodeJS v2 moved them to the module root (and
+    // Characteristic.Formats / .Perms / .Units became undefined). Resolve
+    // them via fallback so this plugin works on both Homebridge 1.x and 2.x.
+    var Formats = (Characteristic && Characteristic.Formats) || (hap && hap.Formats);
+    var Perms   = (Characteristic && Characteristic.Perms)   || (hap && hap.Perms);
+    var Units   = (Characteristic && Characteristic.Units)   || (hap && hap.Units);
+
+    if (!Formats || !Perms || !Units) {
+        throw new Error(
+            'homebridge-edomoticz: cannot resolve HAP Formats/Perms/Units. ' +
+            'Neither Characteristic.* (HAP v1) nor hap.* (HAP v2) provided ' +
+            'them. This indicates an unsupported HAP-NodeJS version.'
+        );
+    }
 
     /* ===== Custom Characteristics (20) ===== */
 
@@ -27,8 +43,8 @@ function initServices(Service, Characteristic, UUID) {
             var charUUID = 'E863F10C-079E-48FF-8F27-9C2605A29F52'; //UUID.generate('eDomoticz:customchar:TotalConsumption');
             super('Total Consumption', charUUID);
             this.setProps({
-                format: Characteristic.Formats.FLOAT,
-                perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY],
+                format: Formats.FLOAT,
+                perms: [Perms.READ, Perms.NOTIFY],
                 unit: 'kWh'
             });
             this.value = this.getDefaultValue();
@@ -41,8 +57,8 @@ function initServices(Service, Characteristic, UUID) {
             var charUUID = UUID.generate('eDomoticz:customchar:TodayConsumption');
             super('Today', charUUID);
             this.setProps({
-                format: Characteristic.Formats.FLOAT,
-                perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY],
+                format: Formats.FLOAT,
+                perms: [Perms.READ, Perms.NOTIFY],
                 unit: 'kWh'
             });
             this.value = this.getDefaultValue();
@@ -55,8 +71,8 @@ function initServices(Service, Characteristic, UUID) {
             var charUUID = 'E863F10D-079E-48FF-8F27-9C2605A29F52'; //UUID.generate('eDomoticz:customchar:CurrentConsumption');
             super('Consumption', charUUID);
             this.setProps({
-                format: Characteristic.Formats.FLOAT,
-                perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY],
+                format: Formats.FLOAT,
+                perms: [Perms.READ, Perms.NOTIFY],
                 unit: 'W'
             });
             this.value = this.getDefaultValue();
@@ -69,8 +85,8 @@ function initServices(Service, Characteristic, UUID) {
             var charUUID = 'E863F126-079E-48FF-8F27-9C2605A29F52'; //AMPERE
             super('Amps', charUUID);
             this.setProps({
-                format: Characteristic.Formats.FLOAT,
-                perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY],
+                format: Formats.FLOAT,
+                perms: [Perms.READ, Perms.NOTIFY],
                 unit: 'A'
             });
             this.value = this.getDefaultValue();
@@ -83,8 +99,8 @@ function initServices(Service, Characteristic, UUID) {
             var charUUID = 'E863F10A-079E-48FF-8F27-9C2605A29F52'; //VOLT
             super('Volts', charUUID);
             this.setProps({
-                format: Characteristic.Formats.FLOAT,
-                perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY],
+                format: Formats.FLOAT,
+                perms: [Perms.READ, Perms.NOTIFY],
                 unit: 'V'
             });
             this.value = this.getDefaultValue();
@@ -99,8 +115,8 @@ function initServices(Service, Characteristic, UUID) {
             var charUUID = UUID.generate('eDomoticz:customchar:CurrentConsumption');
             super('Meter Total', charUUID);
             this.setProps({
-                format: Characteristic.Formats.FLOAT,
-                perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]
+                format: Formats.FLOAT,
+                perms: [Perms.READ, Perms.NOTIFY]
             });
             this.value = this.getDefaultValue();
             this.UUID = charUUID;
@@ -112,8 +128,8 @@ function initServices(Service, Characteristic, UUID) {
             var charUUID = UUID.generate('eDomoticz:customchar:WaterFlow');
             super('Flow Rate', charUUID);
             this.setProps({
-                format: Characteristic.Formats.FLOAT,
-                perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY],
+                format: Formats.FLOAT,
+                perms: [Perms.READ, Perms.NOTIFY],
                 unit: 'm3'
             });
             this.value = this.getDefaultValue();
@@ -126,8 +142,8 @@ function initServices(Service, Characteristic, UUID) {
             var charUUID = UUID.generate('eDomoticz:customchar:TotalWaterFlow');
             super('Flow Total', charUUID);
             this.setProps({
-                format: Characteristic.Formats.FLOAT,
-                perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY],
+                format: Formats.FLOAT,
+                perms: [Perms.READ, Perms.NOTIFY],
                 unit: 'l'
             });
             this.value = this.getDefaultValue();
@@ -141,12 +157,12 @@ function initServices(Service, Characteristic, UUID) {
             var charUUID = UUID.generate('eDomoticz:customchar:OverrideTime');
             super('Override (Mins, 0 = Auto, 481 = Permanent)', charUUID);
             this.setProps({
-                format: Characteristic.Formats.FLOAT,
+                format: Formats.FLOAT,
                 maxValue: 481,
                 minValue: 0,
                 minStep: 1,
                 unit: 'mins',
-                perms: [Characteristic.Perms.READ, Characteristic.Perms.WRITE, Characteristic.Perms.NOTIFY]
+                perms: [Perms.READ, Perms.WRITE, Perms.NOTIFY]
             });
             this.value = this.getDefaultValue();
             this.UUID = charUUID;
@@ -159,9 +175,9 @@ function initServices(Service, Characteristic, UUID) {
             var charUUID = UUID.generate('eDomoticz:customchar:CurrentUsage');
             super('Current Usage', charUUID);
             this.setProps({
-                format: Characteristic.Formats.FLOAT,
-                unit: Characteristic.Units.PERCENTAGE,
-                perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY],
+                format: Formats.FLOAT,
+                unit: Units.PERCENTAGE,
+                perms: [Perms.READ, Perms.NOTIFY],
                 minValue: 0,
                 maxValue: 100,
                 minStep: 0.1
@@ -177,8 +193,8 @@ function initServices(Service, Characteristic, UUID) {
             var charUUID = UUID.generate('eDomoticz:customchar:Location');
             super('Location', charUUID);
             this.setProps({
-                format: Characteristic.Formats.STRING,
-                perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]
+                format: Formats.STRING,
+                perms: [Perms.READ, Perms.NOTIFY]
             });
             this.value = this.getDefaultValue();
             this.UUID = charUUID;
@@ -191,8 +207,8 @@ function initServices(Service, Characteristic, UUID) {
             var charUUID = '49C8AE5A-A3A5-41AB-BF1F-12D5654F9F41';//'9331096F-E49E-4D98-B57B-57803498FA36'; //UUID.generate('eDomoticz:customchar:WindSpeed');
             super('Wind Speed', charUUID);
             this.setProps({
-                format: Characteristic.Formats.FLOAT,
-                perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY],
+                format: Formats.FLOAT,
+                perms: [Perms.READ, Perms.NOTIFY],
                 unit: 'm/s',
                 minValue: 0,
                 maxValue: 360,
@@ -209,9 +225,9 @@ function initServices(Service, Characteristic, UUID) {
             var charUUID = UUID.generate('eDomoticz:customchar:WindChill');
             super('Wind Chill', charUUID);
             this.setProps({
-                format: Characteristic.Formats.FLOAT,
-                perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY],
-                unit: Characteristic.Units.CELSIUS,
+                format: Formats.FLOAT,
+                perms: [Perms.READ, Perms.NOTIFY],
+                unit: Units.CELSIUS,
                 minValue: -50,
                 maxValue: 100,
                 minStep: 0.1
@@ -227,9 +243,9 @@ function initServices(Service, Characteristic, UUID) {
             var charUUID = '46f1284c-1912-421b-82f5-eb75008b167e';//'6C3F6DFA-7340-4ED4-AFFD-0E0310ECCD9E'; //UUID.generate('eDomoticz:customchar:WindDirection');
             super('Wind Direction', charUUID);
             this.setProps({
-                format: Characteristic.Formats.INT,
-                perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY],
-                unit: Characteristic.Units.ARC_DEGREE,
+                format: Formats.INT,
+                perms: [Perms.READ, Perms.NOTIFY],
+                unit: Units.ARC_DEGREE,
                 minValue: 0,
                 maxValue: 360,
                 minStep: 1
@@ -245,8 +261,8 @@ function initServices(Service, Characteristic, UUID) {
             var charUUID = 'ccc04890-565b-4376-b39a-3113341d9e0f';//'C53F35CE-C615-4AA4-9112-EBF679C5EB14'; //UUID.generate('eDomoticz:customchar:Rainfall');
             super('Amount today', charUUID);
             this.setProps({
-                format: Characteristic.Formats.FLOAT,
-                perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY],
+                format: Formats.FLOAT,
+                perms: [Perms.READ, Perms.NOTIFY],
                 unit: 'mm',
                 minValue: 0,
                 maxValue: 360,
@@ -263,8 +279,8 @@ function initServices(Service, Characteristic, UUID) {
             var charUUID = 'd24ecc1e-6fad-4fb5-8137-5af88bd5e857';//UUID.generate('eDomoticz:customchar:Visibility');
             super('Distance', charUUID);
             this.setProps({
-                format: Characteristic.Formats.FLOAT,
-                perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY],
+                format: Formats.FLOAT,
+                perms: [Perms.READ, Perms.NOTIFY],
                 unit: 'miles',
                 minValue: 0,
                 maxValue: 20,
@@ -281,8 +297,8 @@ function initServices(Service, Characteristic, UUID) {
             var charUUID = '05ba0fe0-b848-4226-906d-5b64272e05ce';//UUID.generate('eDomoticz:customchar:Visibility');
             super('UVIndex', charUUID);
             this.setProps({
-                format: Characteristic.Formats.FLOAT,
-                perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY],
+                format: Formats.FLOAT,
+                perms: [Perms.READ, Perms.NOTIFY],
                 unit: 'UVI',
                 minValue: 0,
                 maxValue: 20,
@@ -299,9 +315,9 @@ function initServices(Service, Characteristic, UUID) {
             var charUUID = UUID.generate('eDomoticz:customchar:SolRad');
             super('Radiation', charUUID);
             this.setProps({
-                format: Characteristic.Formats.FLOAT,
+                format: Formats.FLOAT,
                 unit: 'W/m2',
-                perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY],
+                perms: [Perms.READ, Perms.NOTIFY],
                 minValue: 0,
                 maxValue: 10000,
                 minStep: 0.1
@@ -317,8 +333,8 @@ function initServices(Service, Characteristic, UUID) {
             var charUUID = 'E863F10F-079E-48FF-8F27-9C2605A29F52';
             super('Pressure', charUUID);
             this.setProps({
-                format: Characteristic.Formats.FLOAT,
-                perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY],
+                format: Formats.FLOAT,
+                perms: [Perms.READ, Perms.NOTIFY],
                 unit: 'hPA',
                 minValue: 500,
                 maxValue: 2000,
@@ -336,7 +352,7 @@ function initServices(Service, Characteristic, UUID) {
             super('Infotext', charUUID);
             this.setProps({
                 format: 'string',
-                perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]
+                perms: [Perms.READ, Perms.NOTIFY]
             });
             this.value = this.getDefaultValue();
             this.UUID = charUUID;

--- a/lib/services.js
+++ b/lib/services.js
@@ -1,367 +1,482 @@
 var Constants = require('./constants.js');
 
+var eDomoticzServices = {};
+
 module.exports = {
-    eDomoticzServices: eDomoticzServices
+    eDomoticzServices: eDomoticzServices,
+    initServices: initServices
+};
+
+/*
+ * initServices is called from index.js once homebridge has provided its HAP
+ * references. It populates the (already exported) eDomoticzServices object
+ * with ES6 class definitions. The exported object reference does not change,
+ * so consumers that captured it via `require('./services.js').eDomoticzServices`
+ * (e.g. lib/domoticz_accessory.js) keep working transparently.
+ *
+ * Order matters per the migration plan: define the 20 custom Characteristics
+ * first, then the 14 custom Services that compose them.
+ */
+function initServices(Service, Characteristic, UUID) {
+
+    /* ===== Custom Characteristics (20) ===== */
+
+    // PowerMeter Characteristics
+    eDomoticzServices.TotalConsumption = class extends Characteristic {
+        constructor() {
+            var charUUID = 'E863F10C-079E-48FF-8F27-9C2605A29F52'; //UUID.generate('eDomoticz:customchar:TotalConsumption');
+            super('Total Consumption', charUUID);
+            this.setProps({
+                format: Characteristic.Formats.FLOAT,
+                perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY],
+                unit: 'kWh'
+            });
+            this.value = this.getDefaultValue();
+            this.UUID = charUUID;
+        }
+    };
+
+    eDomoticzServices.TodayConsumption = class extends Characteristic {
+        constructor() {
+            var charUUID = UUID.generate('eDomoticz:customchar:TodayConsumption');
+            super('Today', charUUID);
+            this.setProps({
+                format: Characteristic.Formats.FLOAT,
+                perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY],
+                unit: 'kWh'
+            });
+            this.value = this.getDefaultValue();
+            this.UUID = charUUID;
+        }
+    };
+
+    eDomoticzServices.CurrentConsumption = class extends Characteristic {
+        constructor() {
+            var charUUID = 'E863F10D-079E-48FF-8F27-9C2605A29F52'; //UUID.generate('eDomoticz:customchar:CurrentConsumption');
+            super('Consumption', charUUID);
+            this.setProps({
+                format: Characteristic.Formats.FLOAT,
+                perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY],
+                unit: 'W'
+            });
+            this.value = this.getDefaultValue();
+            this.UUID = charUUID;
+        }
+    };
+
+    eDomoticzServices.Ampere = class extends Characteristic {
+        constructor() {
+            var charUUID = 'E863F126-079E-48FF-8F27-9C2605A29F52'; //AMPERE
+            super('Amps', charUUID);
+            this.setProps({
+                format: Characteristic.Formats.FLOAT,
+                perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY],
+                unit: 'A'
+            });
+            this.value = this.getDefaultValue();
+            this.UUID = charUUID;
+        }
+    };
+
+    eDomoticzServices.Volt = class extends Characteristic {
+        constructor() {
+            var charUUID = 'E863F10A-079E-48FF-8F27-9C2605A29F52'; //VOLT
+            super('Volts', charUUID);
+            this.setProps({
+                format: Characteristic.Formats.FLOAT,
+                perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY],
+                unit: 'V'
+            });
+            this.value = this.getDefaultValue();
+            this.UUID = charUUID;
+        }
+    };
+
+    // NOTE: UUID key intentionally reuses 'CurrentConsumption' string — preserved
+    // verbatim from upstream (historical collision, do not "fix").
+    eDomoticzServices.GasConsumption = class extends Characteristic {
+        constructor() {
+            var charUUID = UUID.generate('eDomoticz:customchar:CurrentConsumption');
+            super('Meter Total', charUUID);
+            this.setProps({
+                format: Characteristic.Formats.FLOAT,
+                perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]
+            });
+            this.value = this.getDefaultValue();
+            this.UUID = charUUID;
+        }
+    };
+
+    eDomoticzServices.WaterFlow = class extends Characteristic {
+        constructor() {
+            var charUUID = UUID.generate('eDomoticz:customchar:WaterFlow');
+            super('Flow Rate', charUUID);
+            this.setProps({
+                format: Characteristic.Formats.FLOAT,
+                perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY],
+                unit: 'm3'
+            });
+            this.value = this.getDefaultValue();
+            this.UUID = charUUID;
+        }
+    };
+
+    eDomoticzServices.TotalWaterFlow = class extends Characteristic {
+        constructor() {
+            var charUUID = UUID.generate('eDomoticz:customchar:TotalWaterFlow');
+            super('Flow Total', charUUID);
+            this.setProps({
+                format: Characteristic.Formats.FLOAT,
+                perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY],
+                unit: 'l'
+            });
+            this.value = this.getDefaultValue();
+            this.UUID = charUUID;
+        }
+    };
+
+    // Custom SetPoint Minutes characteristic for TempOverride modes
+    eDomoticzServices.TempOverride = class extends Characteristic {
+        constructor() {
+            var charUUID = UUID.generate('eDomoticz:customchar:OverrideTime');
+            super('Override (Mins, 0 = Auto, 481 = Permanent)', charUUID);
+            this.setProps({
+                format: Characteristic.Formats.FLOAT,
+                maxValue: 481,
+                minValue: 0,
+                minStep: 1,
+                unit: 'mins',
+                perms: [Characteristic.Perms.READ, Characteristic.Perms.WRITE, Characteristic.Perms.NOTIFY]
+            });
+            this.value = this.getDefaultValue();
+            this.UUID = charUUID;
+        }
+    };
+
+    // Usage Meter Characteristics
+    eDomoticzServices.CurrentUsage = class extends Characteristic {
+        constructor() {
+            var charUUID = UUID.generate('eDomoticz:customchar:CurrentUsage');
+            super('Current Usage', charUUID);
+            this.setProps({
+                format: Characteristic.Formats.FLOAT,
+                unit: Characteristic.Units.PERCENTAGE,
+                perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY],
+                minValue: 0,
+                maxValue: 100,
+                minStep: 0.1
+            });
+            this.value = this.getDefaultValue();
+            this.UUID = charUUID;
+        }
+    };
+
+    // Location Characteristic (sensor should have 'Location' in title)
+    eDomoticzServices.Location = class extends Characteristic {
+        constructor() {
+            var charUUID = UUID.generate('eDomoticz:customchar:Location');
+            super('Location', charUUID);
+            this.setProps({
+                format: Characteristic.Formats.STRING,
+                perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]
+            });
+            this.value = this.getDefaultValue();
+            this.UUID = charUUID;
+        }
+    };
+
+    // DarkSkies WindSpeed Characteristic
+    eDomoticzServices.WindSpeed = class extends Characteristic {
+        constructor() {
+            var charUUID = '49C8AE5A-A3A5-41AB-BF1F-12D5654F9F41';//'9331096F-E49E-4D98-B57B-57803498FA36'; //UUID.generate('eDomoticz:customchar:WindSpeed');
+            super('Wind Speed', charUUID);
+            this.setProps({
+                format: Characteristic.Formats.FLOAT,
+                perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY],
+                unit: 'm/s',
+                minValue: 0,
+                maxValue: 360,
+                minStep: 0.1
+            });
+            this.value = this.getDefaultValue();
+            this.UUID = charUUID;
+        }
+    };
+
+    // DarkSkies WindChill Characteristic
+    eDomoticzServices.WindChill = class extends Characteristic {
+        constructor() {
+            var charUUID = UUID.generate('eDomoticz:customchar:WindChill');
+            super('Wind Chill', charUUID);
+            this.setProps({
+                format: Characteristic.Formats.FLOAT,
+                perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY],
+                unit: Characteristic.Units.CELSIUS,
+                minValue: -50,
+                maxValue: 100,
+                minStep: 0.1
+            });
+            this.value = this.getDefaultValue();
+            this.UUID = charUUID;
+        }
+    };
+
+    // DarkSkies WindDirection Characteristic
+    eDomoticzServices.WindDirection = class extends Characteristic {
+        constructor() {
+            var charUUID = '46f1284c-1912-421b-82f5-eb75008b167e';//'6C3F6DFA-7340-4ED4-AFFD-0E0310ECCD9E'; //UUID.generate('eDomoticz:customchar:WindDirection');
+            super('Wind Direction', charUUID);
+            this.setProps({
+                format: Characteristic.Formats.INT,
+                perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY],
+                unit: Characteristic.Units.ARC_DEGREE,
+                minValue: 0,
+                maxValue: 360,
+                minStep: 1
+            });
+            this.value = this.getDefaultValue();
+            this.UUID = charUUID;
+        }
+    };
+
+    // DarkSkies Rain Characteristic
+    eDomoticzServices.Rainfall = class extends Characteristic {
+        constructor() {
+            var charUUID = 'ccc04890-565b-4376-b39a-3113341d9e0f';//'C53F35CE-C615-4AA4-9112-EBF679C5EB14'; //UUID.generate('eDomoticz:customchar:Rainfall');
+            super('Amount today', charUUID);
+            this.setProps({
+                format: Characteristic.Formats.FLOAT,
+                perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY],
+                unit: 'mm',
+                minValue: 0,
+                maxValue: 360,
+                minStep: 0.1
+            });
+            this.value = this.getDefaultValue();
+            this.UUID = charUUID;
+        }
+    };
+
+    // DarkSkies Visibility Characteristic
+    eDomoticzServices.Visibility = class extends Characteristic {
+        constructor() {
+            var charUUID = 'd24ecc1e-6fad-4fb5-8137-5af88bd5e857';//UUID.generate('eDomoticz:customchar:Visibility');
+            super('Distance', charUUID);
+            this.setProps({
+                format: Characteristic.Formats.FLOAT,
+                perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY],
+                unit: 'miles',
+                minValue: 0,
+                maxValue: 20,
+                minStep: 0.1
+            });
+            this.value = this.getDefaultValue();
+            this.UUID = charUUID;
+        }
+    };
+
+    // DarkSkies UVIndex Characteristic
+    eDomoticzServices.UVIndex = class extends Characteristic {
+        constructor() {
+            var charUUID = '05ba0fe0-b848-4226-906d-5b64272e05ce';//UUID.generate('eDomoticz:customchar:Visibility');
+            super('UVIndex', charUUID);
+            this.setProps({
+                format: Characteristic.Formats.FLOAT,
+                perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY],
+                unit: 'UVI',
+                minValue: 0,
+                maxValue: 20,
+                minStep: 0.1
+            });
+            this.value = this.getDefaultValue();
+            this.UUID = charUUID;
+        }
+    };
+
+    // DarkSkies Solar Radiation Characteristic
+    eDomoticzServices.SolRad = class extends Characteristic {
+        constructor() {
+            var charUUID = UUID.generate('eDomoticz:customchar:SolRad');
+            super('Radiation', charUUID);
+            this.setProps({
+                format: Characteristic.Formats.FLOAT,
+                unit: 'W/m2',
+                perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY],
+                minValue: 0,
+                maxValue: 10000,
+                minStep: 0.1
+            });
+            this.value = this.getDefaultValue();
+            this.UUID = charUUID;
+        }
+    };
+
+    // Barometer Characteristic
+    eDomoticzServices.Barometer = class extends Characteristic {
+        constructor() {
+            var charUUID = 'E863F10F-079E-48FF-8F27-9C2605A29F52';
+            super('Pressure', charUUID);
+            this.setProps({
+                format: Characteristic.Formats.FLOAT,
+                perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY],
+                unit: 'hPA',
+                minValue: 500,
+                maxValue: 2000,
+                minStep: 0.1
+            });
+            this.value = this.getDefaultValue();
+            this.UUID = charUUID;
+        }
+    };
+
+    // Infotext Characteristic (free-form string)
+    eDomoticzServices.Infotext = class extends Characteristic {
+        constructor() {
+            var charUUID = UUID.generate('eDomoticz:customchar:Infotext');
+            super('Infotext', charUUID);
+            this.setProps({
+                format: 'string',
+                perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]
+            });
+            this.value = this.getDefaultValue();
+            this.UUID = charUUID;
+        }
+    };
+
+    /* ===== Custom Services (14) ===== */
+
+    // Ampere Meter
+    // NOTE: serviceUUID key intentionally shared with VOLT and Meter device
+    // services (historical upstream behaviour, differentiated by subtype).
+    eDomoticzServices.AMPDeviceService = class extends Service {
+        constructor(displayName, subtype) {
+            var serviceUUID = UUID.generate('eDomoticz:powermeter:customservice');
+            super(displayName, serviceUUID, subtype);
+            this.addCharacteristic(new eDomoticzServices.Ampere());
+        }
+    };
+
+    // Voltage Meter
+    eDomoticzServices.VOLTDeviceService = class extends Service {
+        constructor(displayName, subtype) {
+            var serviceUUID = UUID.generate('eDomoticz:powermeter:customservice');
+            super(displayName, serviceUUID, subtype);
+            this.addCharacteristic(new eDomoticzServices.Volt());
+        }
+    };
+
+    // The PowerMeter itself
+    eDomoticzServices.MeterDeviceService = class extends Service {
+        constructor(displayName, subtype) {
+            var serviceUUID = UUID.generate('eDomoticz:powermeter:customservice');
+            super(displayName, serviceUUID, subtype);
+            this.addCharacteristic(new eDomoticzServices.CurrentConsumption());
+            this.addOptionalCharacteristic(new eDomoticzServices.TotalConsumption());
+            this.addOptionalCharacteristic(new eDomoticzServices.TodayConsumption());
+        }
+    };
+
+    // Waterflow Meter
+    eDomoticzServices.WaterDeviceService = class extends Service {
+        constructor(displayName, subtype) {
+            var serviceUUID = UUID.generate('eDomoticz:watermeter:customservice');
+            super(displayName, serviceUUID, subtype);
+            this.addCharacteristic(new eDomoticzServices.WaterFlow());
+            this.addOptionalCharacteristic(new eDomoticzServices.TotalWaterFlow());
+        }
+    };
+
+    // P1 Smart Meter -> Gas
+    eDomoticzServices.GasDeviceService = class extends Service {
+        constructor(displayName, subtype) {
+            var serviceUUID = UUID.generate('eDomoticz:gasmeter:customservice');
+            super(displayName, serviceUUID, subtype);
+            this.addCharacteristic(new eDomoticzServices.GasConsumption());
+        }
+    };
+
+    // The Usage Meter itself
+    eDomoticzServices.UsageDeviceService = class extends Service {
+        constructor(displayName, subtype) {
+            var serviceUUID = UUID.generate('eDomoticz:usagedevice:customservice');
+            super(displayName, serviceUUID, subtype);
+            this.addCharacteristic(new eDomoticzServices.CurrentUsage());
+        }
+    };
+
+    eDomoticzServices.LocationService = class extends Service {
+        constructor(displayName, subtype) {
+            var serviceUUID = UUID.generate('eDomoticz:location:customservice');
+            super(displayName, serviceUUID, subtype);
+            this.addCharacteristic(new eDomoticzServices.Location());
+        }
+    };
+
+    // DarkSkies Virtual Wind Sensor
+    eDomoticzServices.WindDeviceService = class extends Service {
+        constructor(displayName, subtype) {
+            var serviceUUID = '2AFB775E-79E5-4399-B3CD-398474CAE86C'; //UUID.generate('eDomoticz:winddevice:customservice');
+            super(displayName, serviceUUID, subtype);
+            this.addCharacteristic(new eDomoticzServices.WindSpeed());
+            this.addOptionalCharacteristic(new eDomoticzServices.WindChill());
+            this.addOptionalCharacteristic(new eDomoticzServices.WindDirection());
+            this.addOptionalCharacteristic(new Characteristic.CurrentTemperature());
+        }
+    };
+
+    // DarkSkies Rain Meter itself
+    eDomoticzServices.RainDeviceService = class extends Service {
+        constructor(displayName, subtype) {
+            var serviceUUID = 'D92D5391-92AF-4824-AF4A-356F25F25EA1'; //UUID.generate('eDomoticz:raindevice:customservice');
+            super(displayName, serviceUUID, subtype);
+            this.addCharacteristic(new eDomoticzServices.Rainfall());
+        }
+    };
+
+    // DarkSkies Visibility Meter itself
+    eDomoticzServices.VisibilityDeviceService = class extends Service {
+        constructor(displayName, subtype) {
+            var serviceUUID = UUID.generate('eDomoticz:visibilitydevice:customservice');
+            super(displayName, serviceUUID, subtype);
+            this.addCharacteristic(new eDomoticzServices.Visibility());
+        }
+    };
+
+    // DarkSkies UV Index Meter itself
+    eDomoticzServices.UVDeviceService = class extends Service {
+        constructor(displayName, subtype) {
+            var serviceUUID = UUID.generate('eDomoticz:uvdevice:customservice');
+            super(displayName, serviceUUID, subtype);
+            this.addCharacteristic(new eDomoticzServices.UVIndex());
+        }
+    };
+
+    // DarkSkies Solar Radiation Meter itself
+    eDomoticzServices.SolRadDeviceService = class extends Service {
+        constructor(displayName, subtype) {
+            var serviceUUID = UUID.generate('eDomoticz:solraddevice:customservice');
+            super(displayName, serviceUUID, subtype);
+            this.addCharacteristic(new eDomoticzServices.SolRad());
+        }
+    };
+
+    // Weather Service (Temp + Humidity + Baro composite, surfaced as Eve Weather)
+    eDomoticzServices.WeatherService = class extends Service {
+        constructor(displayName, subtype) {
+            var serviceUUID = 'debf1b79-312e-47f7-bf82-993d9950f3a2';//'E863F001-079E-48FF-8F27-9C2605A29F52';
+            super(displayName, serviceUUID, subtype);
+            this.addCharacteristic(new Characteristic.CurrentTemperature());
+            this.addOptionalCharacteristic(new Characteristic.CurrentRelativeHumidity());
+            this.addOptionalCharacteristic(new eDomoticzServices.Barometer());
+        }
+    };
+
+    // Infotext Device Service
+    eDomoticzServices.InfotextDeviceService = class extends Service {
+        constructor(displayName, subtype) {
+            var serviceUUID = UUID.generate('eDomoticz:infotextdevice:customservice');
+            super(displayName, serviceUUID, subtype);
+            this.addCharacteristic(new eDomoticzServices.Infotext());
+        }
+    };
 }
-
-
-function eDomoticzServices() {
-
-}
-
-/* Define Custom Services & Characteristics */
-// PowerMeter Characteristics
-eDomoticzServices.TotalConsumption = function() {
-    var charUUID = 'E863F10C-079E-48FF-8F27-9C2605A29F52'; //UUID.generate('eDomoticz:customchar:TotalConsumption');
-    Characteristic.call(this, 'Total Consumption', charUUID);
-    this.setProps({
-        format: Characteristic.Formats.FLOAT,
-        perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY],
-        unit: 'kWh'
-    });
-    this.value = this.getDefaultValue();
-    this.UUID = charUUID;
-};
-eDomoticzServices.TodayConsumption = function() {
-    var charUUID = UUID.generate('eDomoticz:customchar:TodayConsumption');
-    Characteristic.call(this, 'Today', charUUID);
-    this.setProps({
-        format: Characteristic.Formats.FLOAT,
-        perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY],
-        unit: 'kWh'
-    });
-    this.value = this.getDefaultValue();
-    this.UUID = charUUID;
-};
-eDomoticzServices.CurrentConsumption = function() {
-    var charUUID = 'E863F10D-079E-48FF-8F27-9C2605A29F52'; //UUID.generate('eDomoticz:customchar:CurrentConsumption');
-    Characteristic.call(this, 'Consumption', charUUID);
-    this.setProps({
-        format: Characteristic.Formats.FLOAT,
-        perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY],
-        unit: 'W'
-    });
-    this.value = this.getDefaultValue();
-    this.UUID = charUUID;
-};
-eDomoticzServices.Ampere = function() {
-    var charUUID = 'E863F126-079E-48FF-8F27-9C2605A29F52'; //AMPERE
-    Characteristic.call(this, 'Amps', charUUID);
-    this.setProps({
-        format: Characteristic.Formats.FLOAT,
-        perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY],
-        unit: 'A'
-    });
-    this.value = this.getDefaultValue();
-    this.UUID = charUUID;
-};
-eDomoticzServices.Volt = function() {
-    var charUUID = 'E863F10A-079E-48FF-8F27-9C2605A29F52'; //VOLT
-    Characteristic.call(this, 'Volts', charUUID);
-    this.setProps({
-        format: Characteristic.Formats.FLOAT,
-        perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY],
-        unit: 'V'
-    });
-    this.value = this.getDefaultValue();
-    this.UUID = charUUID;
-};
-eDomoticzServices.GasConsumption = function() {
-    var charUUID = UUID.generate('eDomoticz:customchar:CurrentConsumption');
-    Characteristic.call(this, 'Meter Total', charUUID);
-    this.setProps({
-        format: Characteristic.Formats.FLOAT,
-        perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]
-    });
-    this.value = this.getDefaultValue();
-    this.UUID = charUUID;
-};
-eDomoticzServices.WaterFlow = function() {
-    var charUUID = UUID.generate('eDomoticz:customchar:WaterFlow');
-    Characteristic.call(this, 'Flow Rate', charUUID);
-    this.setProps({
-        format: Characteristic.Formats.FLOAT,
-        perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY],
-        unit: 'm3'
-    });
-    this.value = this.getDefaultValue();
-    this.UUID = charUUID;
-};
-eDomoticzServices.TotalWaterFlow = function() {
-    var charUUID = UUID.generate('eDomoticz:customchar:TotalWaterFlow');
-    Characteristic.call(this, 'Flow Total', charUUID);
-    this.setProps({
-        format: Characteristic.Formats.FLOAT,
-        perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY],
-        unit: 'l'
-    });
-    this.value = this.getDefaultValue();
-    this.UUID = charUUID;
-};
-// Custom SetPoint Minutes characteristic for TempOverride modes
-eDomoticzServices.TempOverride = function() {
-    var charUUID = UUID.generate('eDomoticz:customchar:OverrideTime');
-    Characteristic.call(this, 'Override (Mins, 0 = Auto, 481 = Permanent)', charUUID);
-    this.setProps({
-        format: Characteristic.Formats.FLOAT,
-        maxValue: 481,
-        minValue: 0,
-        minStep: 1,
-        unit: 'mins',
-        perms: [Characteristic.Perms.READ, Characteristic.Perms.WRITE, Characteristic.Perms.NOTIFY]
-    });
-    this.value = this.getDefaultValue();
-    this.UUID = charUUID;
-};
-// Ampere Meter
-eDomoticzServices.AMPDeviceService = function(displayName, subtype) {
-    var serviceUUID = UUID.generate('eDomoticz:powermeter:customservice');
-    Service.call(this, displayName, serviceUUID, subtype);
-    this.addCharacteristic(new eDomoticzServices.Ampere());
-};
-// Voltage Meter
-eDomoticzServices.VOLTDeviceService = function(displayName, subtype) {
-    var serviceUUID = UUID.generate('eDomoticz:powermeter:customservice');
-    Service.call(this, displayName, serviceUUID, subtype);
-    this.addCharacteristic(new eDomoticzServices.Volt());
-};
-
-// The PowerMeter itself
-eDomoticzServices.MeterDeviceService = function(displayName, subtype) {
-
-    var serviceUUID = UUID.generate('eDomoticz:powermeter:customservice');
-    Service.call(this, displayName, serviceUUID, subtype);
-    this.addCharacteristic(new eDomoticzServices.CurrentConsumption());
-    this.addOptionalCharacteristic(new eDomoticzServices.TotalConsumption());
-    this.addOptionalCharacteristic(new eDomoticzServices.TodayConsumption());
-};
-// Waterflow Meter
-eDomoticzServices.WaterDeviceService = function(displayName, subtype) {
-    var serviceUUID = UUID.generate('eDomoticz:watermeter:customservice');
-    Service.call(this, displayName, serviceUUID, subtype);
-    this.addCharacteristic(new eDomoticzServices.WaterFlow());
-    this.addOptionalCharacteristic(new eDomoticzServices.TotalWaterFlow());
-};
-// P1 Smart Meter -> Gas
-eDomoticzServices.GasDeviceService = function(displayName, subtype) {
-    var serviceUUID = UUID.generate('eDomoticz:gasmeter:customservice');
-    Service.call(this, displayName, serviceUUID, subtype);
-    this.addCharacteristic(new eDomoticzServices.GasConsumption());
-};
-// Usage Meter Characteristics
-eDomoticzServices.CurrentUsage = function() {
-    var charUUID = UUID.generate('eDomoticz:customchar:CurrentUsage');
-    Characteristic.call(this, 'Current Usage', charUUID);
-    this.setProps({
-        format: Characteristic.Formats.FLOAT,
-        unit: Characteristic.Units.PERCENTAGE,
-        perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY],
-        minValue:0,
-        maxValue:100,
-        minStep:0.1
-    });
-    this.value = this.getDefaultValue();
-    this.UUID = charUUID;
-};
-// The Usage Meter itself
-eDomoticzServices.UsageDeviceService = function(displayName, subtype) {
-    var serviceUUID = UUID.generate('eDomoticz:usagedevice:customservice');
-    Service.call(this, displayName, serviceUUID, subtype);
-    this.addCharacteristic(new eDomoticzServices.CurrentUsage());
-};
-// Location Meter (sensor should have 'Location' in title)
-eDomoticzServices.Location = function() {
-    var charUUID = UUID.generate('eDomoticz:customchar:Location');
-    Characteristic.call(this, 'Location', charUUID);
-    this.setProps({
-        format: Characteristic.Formats.STRING,
-        perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]
-    });
-    this.value = this.getDefaultValue();
-    this.UUID = charUUID;
-};
-eDomoticzServices.LocationService = function(displayName, subtype) {
-    var serviceUUID = UUID.generate('eDomoticz:location:customservice');
-    Service.call(this, displayName, serviceUUID, subtype);
-    this.addCharacteristic(new eDomoticzServices.Location());
-};
-// DarkSkies WindSpeed Characteristic
-eDomoticzServices.WindSpeed = function() {
-    var charUUID = '49C8AE5A-A3A5-41AB-BF1F-12D5654F9F41';//'9331096F-E49E-4D98-B57B-57803498FA36'; //UUID.generate('eDomoticz:customchar:WindSpeed');
-    Characteristic.call(this, 'Wind Speed', charUUID);
-    this.setProps({
-        format: Characteristic.Formats.FLOAT,
-        perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY],
-        unit:'m/s',
-        minValue:0,
-        maxValue:360,
-        minStep:0.1
-    });
-    this.value = this.getDefaultValue();
-    this.UUID = charUUID;
-};
-// DarkSkies WindChill Characteristic
-eDomoticzServices.WindChill = function() {
-    var charUUID = UUID.generate('eDomoticz:customchar:WindChill');
-    Characteristic.call(this, 'Wind Chill', charUUID);
-    this.setProps({
-        format: Characteristic.Formats.FLOAT,
-        perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY],
-        unit: Characteristic.Units.CELSIUS,
-        minValue:-50,
-        maxValue:100,
-        minStep:0.1
-    });
-    this.value = this.getDefaultValue();
-    this.UUID = charUUID;
-};
-// DarkSkies WindDirection Characteristic
-eDomoticzServices.WindDirection = function() {
-    var charUUID = '46f1284c-1912-421b-82f5-eb75008b167e';//'6C3F6DFA-7340-4ED4-AFFD-0E0310ECCD9E'; //UUID.generate('eDomoticz:customchar:WindDirection');
-    Characteristic.call(this, 'Wind Direction', charUUID);
-    this.setProps({
-        format: Characteristic.Formats.INT,
-        perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY],
-        unit: Characteristic.Units.ARC_DEGREE,
-        minValue:0,
-        maxValue:360,
-        minStep:1
-    });
-    this.value = this.getDefaultValue();
-    this.UUID = charUUID;
-};
-// DarkSkies Virtual Wind Sensor
-eDomoticzServices.WindDeviceService = function(displayName, subtype) {
-    var serviceUUID = '2AFB775E-79E5-4399-B3CD-398474CAE86C'; //UUID.generate('eDomoticz:winddevice:customservice');
-    Service.call(this, displayName, serviceUUID, subtype);
-    this.addCharacteristic(new eDomoticzServices.WindSpeed());
-    this.addOptionalCharacteristic(new eDomoticzServices.WindChill());
-    this.addOptionalCharacteristic(new eDomoticzServices.WindDirection());
-    this.addOptionalCharacteristic(new Characteristic.CurrentTemperature());
-};
-// DarkSkies Rain Characteristics
-eDomoticzServices.Rainfall = function() {
-    var charUUID = 'ccc04890-565b-4376-b39a-3113341d9e0f';//'C53F35CE-C615-4AA4-9112-EBF679C5EB14'; //UUID.generate('eDomoticz:customchar:Rainfall');
-    Characteristic.call(this, 'Amount today', charUUID);
-    this.setProps({
-        format: Characteristic.Formats.FLOAT,
-        perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY],
-        unit: 'mm',
-        minValue:0,
-        maxValue:360,
-        minStep:0.1
-    });
-    this.value = this.getDefaultValue();
-    this.UUID = charUUID;
-};
-// DarkSkies Rain Meter itself
-eDomoticzServices.RainDeviceService = function(displayName, subtype) {
-    var serviceUUID = 'D92D5391-92AF-4824-AF4A-356F25F25EA1'; //UUID.generate('eDomoticz:raindevice:customservice');
-    Service.call(this, displayName, serviceUUID, subtype);
-    this.addCharacteristic(new eDomoticzServices.Rainfall());
-};
-// DarkSkies Visibility Characteristics
-eDomoticzServices.Visibility = function() {
-    var charUUID = 'd24ecc1e-6fad-4fb5-8137-5af88bd5e857';//UUID.generate('eDomoticz:customchar:Visibility');
-    Characteristic.call(this, 'Distance', charUUID);
-    this.setProps({
-        format: Characteristic.Formats.FLOAT,
-        perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY],
-        unit: 'miles',
-        minValue:0,
-        maxValue:20,
-        minStep:0.1
-    });
-    this.value = this.getDefaultValue();
-    this.UUID = charUUID;
-};
-// DarkSkies Visibility Meter itself
-eDomoticzServices.VisibilityDeviceService = function(displayName, subtype) {
-    var serviceUUID = UUID.generate('eDomoticz:visibilitydevice:customservice');
-    Service.call(this, displayName, serviceUUID, subtype);
-    this.addCharacteristic(new eDomoticzServices.Visibility());
-};
-// DarkSkies UVIndex Characteristics
-eDomoticzServices.UVIndex = function() {
-    var charUUID = '05ba0fe0-b848-4226-906d-5b64272e05ce';//UUID.generate('eDomoticz:customchar:Visibility');
-    Characteristic.call(this, 'UVIndex', charUUID);
-    this.setProps({
-        format: Characteristic.Formats.FLOAT,
-        perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY],
-        unit: 'UVI',
-        minValue:0,
-        maxValue:20,
-        minStep:0.1
-    });
-    this.value = this.getDefaultValue();
-    this.UUID = charUUID;
-};
-
-// DarkSkies UV Index Meter itself
-eDomoticzServices.UVDeviceService = function(displayName, subtype) {
-    var serviceUUID = UUID.generate('eDomoticz:uvdevice:customservice');
-    Service.call(this, displayName, serviceUUID, subtype);
-    this.addCharacteristic(new eDomoticzServices.UVIndex());
-};
-// DarkSkies Solar Radiation Characteristics
-eDomoticzServices.SolRad = function() {
-    var charUUID = UUID.generate('eDomoticz:customchar:SolRad');
-    Characteristic.call(this, 'Radiation', charUUID);
-    this.setProps({
-        format: Characteristic.Formats.FLOAT,
-        unit: 'W/m2',
-        perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY],
-        minValue:0,
-        maxValue:10000,
-        minStep:0.1
-    });
-    this.value = this.getDefaultValue();
-    this.UUID = charUUID;
-};
-// DarkSkies Solar Radiation Meter itself
-eDomoticzServices.SolRadDeviceService = function(displayName, subtype) {
-    var serviceUUID = UUID.generate('eDomoticz:solraddevice:customservice');
-    Service.call(this, displayName, serviceUUID, subtype);
-    this.addCharacteristic(new eDomoticzServices.SolRad());
-};
-// Barometer Characteristic
-eDomoticzServices.Barometer = function() {
-    var charUUID = 'E863F10F-079E-48FF-8F27-9C2605A29F52';
-    Characteristic.call(this, 'Pressure', charUUID);
-    this.setProps({
-        format: Characteristic.Formats.FLOAT,
-        perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY],
-        unit: 'hPA',
-        minValue: 500,
-		maxValue: 2000,
-		minStep: 0.1
-    });
-    this.value = this.getDefaultValue();
-    this.UUID = charUUID;
-};
-// Weather Service
-eDomoticzServices.WeatherService = function(displayName, subtype) {
-    var serviceUUID = 'debf1b79-312e-47f7-bf82-993d9950f3a2';//'E863F001-079E-48FF-8F27-9C2605A29F52';
-    Service.call(this, displayName, serviceUUID, subtype);
-    this.addCharacteristic(new Characteristic.CurrentTemperature());
-    this.addOptionalCharacteristic(new Characteristic.CurrentRelativeHumidity());
-    this.addOptionalCharacteristic(new eDomoticzServices.Barometer());
-};
-// DarkSkies Visibility Characteristics
-eDomoticzServices.Infotext = function() {
-    var charUUID = UUID.generate('eDomoticz:customchar:Infotext');
-    Characteristic.call(this, 'Infotext', charUUID);
-    this.setProps({
-        format: 'string',
-        perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]
-    });
-    this.value = this.getDefaultValue();
-    this.UUID = charUUID;
-};
-// DarkSkies Visibility Meter itself
-eDomoticzServices.InfotextDeviceService = function(displayName, subtype) {
-    var serviceUUID = UUID.generate('eDomoticz:infotextdevice:customservice');
-    Service.call(this, displayName, serviceUUID, subtype);
-    this.addCharacteristic(new eDomoticzServices.Infotext());
-};
-/* End of Custom Services & Characteristics */

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "Domoticz"
   ],
   "engines": {
-    "node": ">=0.12.0",
-    "homebridge": ">=0.2.5"
+    "node": ">=18.15.0",
+    "homebridge": ">=1.8.0 || >=2.0.0"
   },
   "dependencies": {
     "inherits": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "homebridge-plugin for Domoticz https://github.com/nfarina/homebridge",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node test/load-plugin.js"
   },
   "repository": {
     "type": "git",
@@ -24,6 +24,10 @@
     "inherits": "^2.0.1",
     "mqtt": "^2.15.0",
     "request": "^2.81.0"
+  },
+  "devDependencies": {
+    "@homebridge/hap-nodejs": "^2.1.0",
+    "homebridge": "^2.0.0"
   },
   "author": {
     "name": "PatchworkBoy",

--- a/test/load-plugin.js
+++ b/test/load-plugin.js
@@ -1,0 +1,149 @@
+'use strict';
+/*
+ * test/load-plugin.js
+ *
+ * Smoke test for the Homebridge 2.x / HAP-NodeJS v2 compatibility migration.
+ *
+ * It does NOT load the full plugin (index.js) on purpose: index.js pulls
+ * domoticz_accessory.js + request + mqtt etc., and we want a focused check
+ * on the migration itself. Instead it replicates what index.js does on
+ * startup -- read Service/Characteristic/uuid from HAP, call initServices --
+ * and then instantiates a representative battery of subclasses.
+ *
+ * The original v2.1.50 plugin crashed under HAP-NodeJS v2 with:
+ *     TypeError: Class constructor Service cannot be invoked without 'new'
+ *         at new eDomoticzServices.MeterDeviceService (lib/services.js:133:13)
+ * This test will catch any regression of that bug.
+ *
+ * Coverage:
+ *   - Characteristic with fixed Eve UUID            -> CurrentConsumption
+ *   - Characteristic with UUID.generate              -> TodayConsumption
+ *   - Characteristic with historical UUID collision  -> GasConsumption
+ *   - The 3 Services that share 'eDomoticz:powermeter:customservice'
+ *     (differentiated only by subtype) -> AMP / VOLT / Meter
+ *   - Service with fixed UUID                        -> WindDeviceService
+ *   - Service that composes a HAP stock Characteristic
+ *     (Characteristic.CurrentTemperature)            -> WeatherService
+ *
+ * Exit codes:
+ *   0  -> all instantiations succeeded
+ *   2  -> @homebridge/hap-nodejs not installed (run `npm install` first)
+ *   3  -> initServices threw
+ *   1  -> at least one instantiation threw
+ */
+
+let hap;
+try {
+    hap = require('@homebridge/hap-nodejs');
+} catch (e) {
+    console.error('FAIL: @homebridge/hap-nodejs is not installed. Run `npm install` first.');
+    console.error(e && e.stack ? e.stack : e);
+    process.exit(2);
+}
+
+// 1. Load the migrated services module
+const Services = require('../lib/services.js');
+
+// 2. Replicate what index.js does on startup: hand HAP refs to the factory.
+//    The 4th argument (the hap module itself) lets initServices resolve the
+//    Formats/Perms/Units enums under HAP v2, where they live on the module
+//    root rather than on the Characteristic class.
+try {
+    Services.initServices(hap.Service, hap.Characteristic, hap.uuid, hap);
+} catch (e) {
+    console.error('FAIL: Services.initServices threw.');
+    console.error(e && e.stack ? e.stack : e);
+    process.exit(3);
+}
+
+const eDomoticzServices = Services.eDomoticzServices;
+
+// 3. Instantiate representatives
+const cases = [
+    // --- Characteristics ---
+    {
+        label: 'Characteristic, fixed Eve UUID (CurrentConsumption)',
+        run: function () { return new eDomoticzServices.CurrentConsumption(); },
+    },
+    {
+        label: 'Characteristic, UUID.generate (TodayConsumption)',
+        run: function () { return new eDomoticzServices.TodayConsumption(); },
+    },
+    {
+        label: 'Characteristic, historical UUID collision (GasConsumption)',
+        run: function () { return new eDomoticzServices.GasConsumption(); },
+    },
+
+    // --- The 3 Services sharing UUID 'eDomoticz:powermeter:customservice' ---
+    {
+        label: "Service, shared UUID key, subtype='sub-amp' (AMPDeviceService)",
+        run: function () { return new eDomoticzServices.AMPDeviceService('AMP', 'sub-amp'); },
+    },
+    {
+        label: "Service, shared UUID key, subtype='sub-volt' (VOLTDeviceService)",
+        run: function () { return new eDomoticzServices.VOLTDeviceService('VOLT', 'sub-volt'); },
+    },
+    {
+        label: "Service, shared UUID key, subtype='sub-meter' (MeterDeviceService) -- original crash site",
+        run: function () { return new eDomoticzServices.MeterDeviceService('Meter', 'sub-meter'); },
+    },
+
+    // --- Other shapes ---
+    {
+        label: 'Service, fixed UUID (WindDeviceService)',
+        run: function () { return new eDomoticzServices.WindDeviceService('Wind', 'sub-wind'); },
+    },
+    {
+        label: 'Service composing HAP stock + custom Characteristic (WeatherService)',
+        run: function () { return new eDomoticzServices.WeatherService('Weather', 'sub-weather'); },
+    },
+];
+
+let ok = 0;
+let failed = 0;
+const collisionUUIDs = [];
+
+for (const c of cases) {
+    try {
+        const inst = c.run();
+        if (!inst) throw new Error('instance is falsy');
+        ok++;
+        // Capture the UUID of the three colliding services so we can assert
+        // afterwards that they really do share the same UUID and differ only
+        // in subtype (the historical upstream invariant).
+        if (/AMPDeviceService|VOLTDeviceService|MeterDeviceService/.test(c.label)) {
+            collisionUUIDs.push({ label: c.label.split(' (')[1].replace(')', ''), uuid: inst.UUID, subtype: inst.subtype });
+        }
+        console.log('  OK   ' + c.label + '  ->  UUID=' + inst.UUID + (inst.subtype ? ', subtype=' + inst.subtype : ''));
+    } catch (e) {
+        failed++;
+        const stack = e && e.stack ? e.stack.split('\n').slice(0, 4).join('\n         ') : String(e);
+        console.error('  FAIL ' + c.label);
+        console.error('         ' + stack);
+    }
+}
+
+// Assert the historical collision is preserved: same UUID across the 3
+// services, distinct subtypes.
+if (failed === 0 && collisionUUIDs.length === 3) {
+    const uniqueUUIDs = new Set(collisionUUIDs.map(function (x) { return x.uuid; }));
+    const uniqueSubtypes = new Set(collisionUUIDs.map(function (x) { return x.subtype; }));
+    if (uniqueUUIDs.size !== 1) {
+        failed++;
+        console.error('  FAIL collision invariant: the 3 powermeter services should share one UUID, got ' + uniqueUUIDs.size + ' distinct UUIDs.');
+    } else if (uniqueSubtypes.size !== 3) {
+        failed++;
+        console.error('  FAIL collision invariant: subtypes should be distinct, got ' + uniqueSubtypes.size + '.');
+    } else {
+        console.log('  OK   collision invariant: 3 services share UUID ' + Array.from(uniqueUUIDs)[0] + ' with 3 distinct subtypes');
+    }
+}
+
+if (failed) {
+    console.error('\n' + failed + ' check(s) failed.');
+    process.exit(1);
+}
+
+console.log('\nOK: ' + ok + ' instanciaciones completadas');
+console.log('Carga + instanciacion OK');
+process.exit(0);


### PR DESCRIPTION
## Motivation

  This PR brings `homebridge-edomoticz` back to a working state under
  Homebridge 2.x / HAP-NodeJS v2. Out of the box, v2.1.50 fails to load on
  HB 2.x with:

      TypeError: Class constructor Service cannot be invoked without 'new'
          at new eDomoticzServices.MeterDeviceService (lib/services.js:133:13)

  …and even after fixing that, every Characteristic constructor breaks with
  a second, unrelated HAP v2 change.

  I have been running these commits on my own Homebridge 2.0.2 + Domoticz
  setup for the past few days against ~20 devices (lamps, dimmers, motion
  sensors, temperature sensors, smart plugs, security panel, MQTT) without
  issues. Offered upstream in case you want to integrate them. No pressure
  either way -- the same work is also published as a fork at
  https://github.com/cmendozac/homebridge-edomoticz for anyone who needs it
  immediately.

  ## Commits (7, atomic)

  1. **`refactor: migrate Service/Characteristic classes to ES6 extends`**
     The 20 custom Characteristics and 14 custom Services in `lib/services.js`
     moved from pre-ES6 constructors + `util.inherits` to
     `class … extends Service|Characteristic`. The class bodies live in an
     `initServices(Service, Characteristic, UUID, hap)` factory exported
     alongside the (unchanged) `eDomoticzServices` object reference, so
     consumers like `lib/domoticz_accessory.js` need no changes.

  2. **`refactor: drop util.inherits calls, invoke initServices factory`**
     Companion change to `index.js`: removes the 34 `util.inherits(...)`
     calls (now redundant under `class extends`) and adds a single call to
     `initServices` once `homebridge.hap` is available.

  3. **`chore: bump engines to match Homebridge 2.x minimums`**
     `engines.node`: `>=0.12.0` → `>=18.15.0`.
     `engines.homebridge`: `>=0.2.5` → `>=1.8.0 || >=2.0.0` (keeps 1.x
     compatibility so this is not a hard break). `version`,
     `repository.url`, `bugs.url`, `homepage` are intentionally left
     untouched -- those are your release/release-notes decisions, not mine.

  4. **`chore: add devDependencies and test infrastructure`**
     `scripts.test` runs the new smoke test; `devDependencies` adds
     `@homebridge/hap-nodejs ^2.1.0` (the HAP-NodeJS v2 package Homebridge
     2.x ships) and `homebridge ^2.0.0` so the test runs against the real
     bundle.

  5. **`fix: resolve HAP Formats/Perms/Units via fallback for HAP v2 compat`**
     HAP-NodeJS v2 moved `Formats`, `Perms` and `Units` from static
     properties of the `Characteristic` class to the root of the `hap`
     module (verified empirically with `@homebridge/hap-nodejs@2.1.6`).
     `initServices` now resolves them via a v1/v2 fallback with a defensive
     `Error` if neither layout provides them. The 42 enum references in the
     constructors (`Characteristic.Formats.X` → `Formats.X`, etc.) are
     substituted mechanically inside the same setProps blocks. UUIDs,
     display names, setProps numerics, unit strings and added (optional)
     characteristics are byte-identical to the previous code.

  6. **`test: add load+instantiate smoke test against hap-nodejs v2`**
     `test/load-plugin.js` runs `initServices` against a real
     `@homebridge/hap-nodejs@2.x` and instantiates a representative class
     from each shape (fixed Eve UUID, `UUID.generate`, the historical UUID
     collision on `'eDomoticz:customchar:CurrentConsumption'`, the three
     services that share `'eDomoticz:powermeter:customservice'` with
     distinct subtypes, fixed UUID, composite with HAP stock characteristic).
     Asserts the AMP/VOLT/Meter shared-UUID invariant explicitly.

     Exit codes are explicit (0/1/2/3) so failures are bisect-friendly.

  7. **`fix: remove dead callback() invocations in error branches`**
     Pre-existing latent bug, unrelated to HB 2.x: `lib/domoticz.js:51` and
     `:211` invoke an undeclared `callback()` symbol inside the
     network-error branches of `Domoticz.settings` and
     `Domoticz.updateWithURL`. If either branch is reached (Domoticz down,
     non-200, malformed JSON), Node throws `ReferenceError` and the plugin
     process dies. Both lines are simply removed; the surrounding `error()`
     and `Helper.LogConnectionError(...)` are kept so legitimate error
     handling still works.

  ## Invariants explicitly preserved

  These were the non-negotiables I held to throughout the refactor:

  - **All Service / Characteristic UUIDs are byte-identical**, including
    the historical collisions on `'eDomoticz:powermeter:customservice'`
    (shared by AMP/VOLT/Meter, differentiated only by subtype) and
    `'eDomoticz:customchar:CurrentConsumption'` (reused as the seed for
    `GasConsumption`). These are quirks but they are also the identity of
    the services/characteristics for HomeKit pairings -- changing them
    would break every existing install. The smoke test asserts the
    AMP/VOLT/Meter UUID collision explicitly.
  - **Public API untouched**: no change to `config.json` schema, platform
    name (`eDomoticz`), or visible runtime behaviour.
  - **`lib/domoticz_accessory.js` not touched** (the 2352-line file). The
    refactor goes through the `eDomoticzServices.X` factory; that file
    keeps working transparently.

  ## How to validate locally

      npm install
      npm test

  Expected: 8 instantiation cases pass, the collision invariant passes,
  exit 0.

  ## Notes

  - I have intentionally NOT bumped `version`, `repository.url`, `bugs.url`
    or `homepage` -- those are your call.
  - I have intentionally NOT touched the `request` deprecation, the
    implicit-global pattern in `index.js`, or the dead
    `Helper.fixInheritance`. They are pre-existing concerns orthogonal to
    HB 2.x compat; happy to follow up in separate PRs if useful.
  - Commits are kept atomic and revertible individually if you only want
    part of the change.

  Feel free to squash/rebase/edit at your discretion. Marking "Allow edits
  by maintainers".

  Thanks for the original plugin -- it's been running my home for years.